### PR TITLE
Update materials option + automatically install rhino3dm

### DIFF
--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -38,7 +38,7 @@ import bpy
 # invoke() function which calls the file selector.
 from bpy_extras.io_utils import ImportHelper
 from bpy.props import StringProperty, BoolProperty, EnumProperty
-from bpy.types import Operator, AddonPreferences
+from bpy.types import Operator
 
 from .read3dm import read_3dm
 

--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -38,9 +38,7 @@ import bpy
 # invoke() function which calls the file selector.
 from bpy_extras.io_utils import ImportHelper
 from bpy.props import StringProperty, BoolProperty, EnumProperty
-from bpy.types import Operator
-
-import rhino3dm as r3d
+from bpy.types import Operator, AddonPreferences
 
 from .read3dm import read_3dm
 
@@ -98,7 +96,6 @@ class Import3dm(Operator, ImportHelper):
 
     def execute(self, context):
         return read_3dm(context, self.filepath, self.import_hidden, self.import_views, self.import_named_views, self.update_materials)
-
 
 # Only needed if you want to add into a dynamic menu
 def menu_func_import(self, context):

--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -68,16 +68,23 @@ class Import3dm(Operator, ImportHelper):
     )
 
     import_views: BoolProperty(
-        name="Import views.",
+        name="Import standard views.",
         description="Import standard views (Top, Front, Right, Perspective) as cameras.",
-        default=True,
+        default=False,
     )
 
     import_named_views: BoolProperty(
         name="Import named views.",
         description="Import named views as cameras.",
         default=True,
-    )       
+    )
+
+
+    update_materials: BoolProperty(
+        name="Update materials.",
+        description="Update existing materials. Otherwise, create new materials if existing ones are found.",
+        default=True,
+    )          
 
 #    type: EnumProperty(
 #        name="Example Enum",
@@ -90,7 +97,7 @@ class Import3dm(Operator, ImportHelper):
 #    )
 
     def execute(self, context):
-        return read_3dm(context, self.filepath, self.import_hidden, self.import_views, self.import_named_views)
+        return read_3dm(context, self.filepath, self.import_hidden, self.import_views, self.import_named_views, self.update_materials)
 
 
 # Only needed if you want to add into a dynamic menu

--- a/import_3dm/converters/layers.py
+++ b/import_3dm/converters/layers.py
@@ -25,7 +25,7 @@ import rhino3dm as r3d
 from . import utils
 
 
-def handle_layers(context, model, toplayer, layerids, materials):
+def handle_layers(context, model, toplayer, layerids, materials, update):
     """
     In context read the Rhino layers from model
     then update the layerids dictionary passed in.
@@ -42,10 +42,11 @@ def handle_layers(context, model, toplayer, layerids, materials):
         matname = l.Name + "+" + str(l.Id)
         if matname not in materials:
             laymat = utils.get_iddata(context.blend_data.materials, l.Id, l.Name, None)
-            laymat.use_nodes = True
-            r, g, b, _ = l.Color
-            principled = PrincipledBSDFWrapper(laymat, is_readonly=False)
-            principled.base_color = (r/255.0, g/255.0, b/255.0)
+            if update:
+	            laymat.use_nodes = True
+	            r, g, b, _ = l.Color
+	            principled = PrincipledBSDFWrapper(laymat, is_readonly=False)
+	            principled.base_color = (r/255.0, g/255.0, b/255.0)
             materials[matname] = laymat
     # second pass so we can link layers to each other
     for l in model.Layers:

--- a/import_3dm/converters/material.py
+++ b/import_3dm/converters/material.py
@@ -100,39 +100,40 @@ def material_name(m):
     return m.Name + "~" + str(h)
 
 
-def handle_materials(context, model, materials):
+def handle_materials(context, model, materials, update):
     """
     """
     for m in model.Materials:
         matname = material_name(m)
         if matname not in materials:
             blmat = utils.get_iddata(context.blend_data.materials, None, m.Name, None)
-            blmat.use_nodes = True
-            refl = m.Reflectivity
-            transp = m.Transparency
-            ior = m.IndexOfRefraction
-            roughness = m.ReflectionGlossiness
-            transrough = m.RefractionGlossiness
-            spec = m.Shine / 255.0
-            
-            if m.DiffuseColor == _black and m.Reflectivity > 0.0 and m.Transparency == 0.0:
-                r, g, b, _ = m.ReflectionColor
-            elif m.DiffuseColor == _black and m.Reflectivity == 0.0 and m.Transparency > 0.0:
-                r, g, b, _ = m.TransparentColor
-                refl = 0.0
-            elif m.DiffuseColor == _black and m.Reflectivity > 0.0 and m.Transparency > 0.0:
-                r, g, b, _ = m.TransparentColor
-                refl = 0.0
-            else:
-                r, g, b, a = m.DiffuseColor
-                if refl > 0.0 and transp > 0.0:
+            if update:
+                blmat.use_nodes = True
+                refl = m.Reflectivity
+                transp = m.Transparency
+                ior = m.IndexOfRefraction
+                roughness = m.ReflectionGlossiness
+                transrough = m.RefractionGlossiness
+                spec = m.Shine / 255.0
+                
+                if m.DiffuseColor == _black and m.Reflectivity > 0.0 and m.Transparency == 0.0:
+                    r, g, b, _ = m.ReflectionColor
+                elif m.DiffuseColor == _black and m.Reflectivity == 0.0 and m.Transparency > 0.0:
+                    r, g, b, _ = m.TransparentColor
                     refl = 0.0
-            principled = PrincipledBSDFWrapper(blmat, is_readonly=False)
-            principled.base_color = (r/255.0, g/255.0, b/255.0)
-            principled.metallic = refl
-            principled.transmission = transp
-            principled.ior = ior
-            principled.roughness = roughness
-            principled.specular = spec
-            principled.node_principled_bsdf.inputs[16].default_value = transrough
+                elif m.DiffuseColor == _black and m.Reflectivity > 0.0 and m.Transparency > 0.0:
+                    r, g, b, _ = m.TransparentColor
+                    refl = 0.0
+                else:
+                    r, g, b, a = m.DiffuseColor
+                    if refl > 0.0 and transp > 0.0:
+                        refl = 0.0
+                principled = PrincipledBSDFWrapper(blmat, is_readonly=False)
+                principled.base_color = (r/255.0, g/255.0, b/255.0)
+                principled.metallic = refl
+                principled.transmission = transp
+                principled.ior = ior
+                principled.roughness = roughness
+                principled.specular = spec
+                principled.node_principled_bsdf.inputs[16].default_value = transrough
             materials[matname] = blmat

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -45,9 +45,7 @@ def install_dependencies():
             from pip._internal import main as pipmain
 
         res = pipmain(["install", "rhino3dm"])
-        if res == 0:
-            import rhino3dm
-        else:
+        if res > 0:
             raise Exception("Failed to install rhino3dm.")
     except:
         raise Exception("Failed to install dependencies. Please make sure you have pip installed.")

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -25,7 +25,7 @@ import bpy
 import rhino3dm as r3d
 from . import converters
 
-def read_3dm(context, filepath, import_hidden, import_views, import_named_views):
+def read_3dm(context, filepath, import_hidden, import_views, import_named_views, update_materials):
     top_collection_name = os.path.splitext(os.path.basename(filepath))[0]
     if top_collection_name in context.blend_data.collections.keys():
         toplayer = context.blend_data.collections[top_collection_name]
@@ -46,9 +46,9 @@ def read_3dm(context, filepath, import_hidden, import_views, import_named_views)
     if import_named_views:
         converters.handle_views(context, model, toplayer, model.NamedViews, "NamedViews", scale)
 
-    converters.handle_materials(context, model, materials)
+    converters.handle_materials(context, model, materials, update_materials)
 
-    converters.handle_layers(context, model, toplayer, layerids, materials)
+    converters.handle_layers(context, model, toplayer, layerids, materials, update_materials)
 
     for ob in model.Objects:
         og = ob.Geometry

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -22,7 +22,43 @@
 
 import os.path
 import bpy
-import rhino3dm as r3d
+
+def install_dependencies():
+    try:
+        try:
+            import pip
+        except:
+            from subprocess import call
+            print("Installing pip... "),
+            res = call("{} -m ensurepip".format(bpy.app.binary_path_python))
+
+            if res == 0:
+                import pip
+            else:
+                raise Exception("Failed to install pip.")
+
+        print("Installing rhino3dm... "),
+
+        try:
+            from pip import main as pipmain
+        except:
+            from pip._internal import main as pipmain
+
+        res = pipmain(["install", "rhino3dm"])
+        if res == 0:
+            import speckle
+        else:
+            raise Exception("Failed to install rhino3dm.")
+    except:
+        raise Exception("Failed to install dependencies. Please make sure you have pip installed.")
+
+try:
+    import rhino3dm as r3d
+except:
+    print("Failed to load rhino3dm.")
+    install_dependencies()
+    import rhino3dm as r3d
+
 from . import converters
 
 def read_3dm(context, filepath, import_hidden, import_views, import_named_views, update_materials):

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -46,7 +46,7 @@ def install_dependencies():
 
         res = pipmain(["install", "rhino3dm"])
         if res == 0:
-            import speckle
+            import rhino3dm
         else:
             raise Exception("Failed to install rhino3dm.")
     except:

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -54,8 +54,13 @@ try:
     import rhino3dm as r3d
 except:
     print("Failed to load rhino3dm.")
-    install_dependencies()
-    import rhino3dm as r3d
+    from sys import platform
+    if platform == "win32":
+        install_dependencies()
+        import rhino3dm as r3d
+    else:
+        print("Platform {} cannot automatically install dependencies.".format(platform))
+        raise
 
 from . import converters
 


### PR DESCRIPTION
# Update materials option
Adds option to update previously imported materials.

## detailed explanation
* Adds update option (boolean) to 3dm import. Updates existing materials, otherwise creates new materials if existing ones are found. This allows making tweaks in Blender to materials and re-importing / updating the 3dm.

# Automatically install dependencies
Tries to import `rhino3dm` and installs it using `pip` if it fails.

## detailed explanation
* Tries to import `rhino3dm`, attempts to install it using `pip`
* Tries to use `pip`, installs it if it fails

