### PR TITLE
Basic curve import

### DIFF
--- a/import_3dm/converters/curve.py
+++ b/import_3dm/converters/curve.py
@@ -45,6 +45,8 @@ def import_polyline(rcurve, bcurve, scale):
     polyline = bcurve.splines.new('POLY')
 
     polyline.use_cyclic_u = rcurve.IsClosed
+    if rcurve.IsClosed:
+        N -= 1
 
     polyline.points.add(N - 1)
     for i in range(0, N):
@@ -85,9 +87,14 @@ CONVERT = {
 def import_polycurve(rcurve, bcurve, scale):
     return
 
+    ncurve = rcurve.ToNurbsCurve()
+    return import_nurbs_curve(ncurve, bcurve, scale)
+
+    '''
     for seg in rcurve.segments:
         if type(seg) in CONVERT.keys():
             CONVERT[type(seg)](seg, bcurve, scale)
+    '''
 
 CONVERT[r3d.Polycurve] = import_polycurve
 
@@ -101,8 +108,6 @@ def import_curve(og,context, n, Name, Id, layer, rhinomat, scale):
 
     CONVERT[type(og)](og, curve_data, scale)
 
-    #print("Curve type: {}".format(speckle_curve["type"]))
-
     add_curve(context, n, Name, Id, curve_data, layer, rhinomat)
 
 def add_curve(context, name, origname, id, cdata, layer, rhinomat):
@@ -110,6 +115,7 @@ def add_curve(context, name, origname, id, cdata, layer, rhinomat):
     cdata.materials.append(rhinomat)
 
     ob = utils.get_iddata(context.blend_data.objects, id, origname, cdata)
+
     # Rhino data is all in world space, so add object at 0,0,0
     ob.location = (0.0, 0.0, 0.0)
     try:

--- a/import_3dm/converters/curve.py
+++ b/import_3dm/converters/curve.py
@@ -25,5 +25,94 @@ import rhino3dm as r3d
 from  . import utils
 
 
+def import_line(rcurve, bcurve, scale):
+
+    fr = rcurve.Line.From
+    to = rcurve.Line.To
+
+    line = bcurve.splines.new('POLY')
+    line.points.add(1)
+
+    line.points[0].co = (fr.X * scale, fr.Y * scale, fr.Z * scale, 1)
+    line.points[1].co = (to.X * scale, to.Y * scale, to.Z * scale, 1)
+
+    return line
+
+def import_polyline(rcurve, bcurve, scale):
+
+    N = rcurve.PointCount
+
+    polyline = bcurve.splines.new('POLY')
+
+    polyline.use_cyclic_u = rcurve.IsClosed
+
+    polyline.points.add(N - 1)
+    for i in range(0, N):
+        rpt = rcurve.Point(i)
+        polyline.points[i].co = (rpt.X * scale, rpt.Y * scale, rpt.Z * scale, 1)
+
+    return polyline
+
+def import_nurbs_curve(rcurve, bcurve, scale):
+
+    N = len(rcurve.Points)
+
+    nurbs = bcurve.splines.new('NURBS')
+    nurbs.use_cyclic_u = rcurve.IsClosed
+
+    nurbs.points.add(N - 1)
+    for i in range(0, N):
+        rpt = rcurve.Points[i]
+        nurbs.points[i].co = (rpt.X * scale, rpt.Y * scale, rpt.Z * scale, rpt.W * scale)
+
+    #nurbs.use_bezier_u = True
+    nurbs.use_endpoint_u = True
+    nurbs.order_u = rcurve.Order
+            
+    return nurbs        
+
+def import_null(rcurve, bcurve, scale):
+    print("Failed to convert type", type(rcurve))
+    return None
+
+CONVERT = {
+    r3d.NurbsCurve: import_nurbs_curve,
+    r3d.LineCurve: import_line,
+    r3d.Polylinecurve: import_polyline,
+    r3d.ArcCurve:import_null
+}
+
+def import_polycurve(rcurve, bcurve, scale):
+    return
+
+    for seg in rcurve.segments:
+        if type(seg) in CONVERT.keys():
+            CONVERT[type(seg)](seg, bcurve, scale)
+
+CONVERT[r3d.Polycurve] = import_polycurve
+
+
 def import_curve(og,context, n, Name, Id, layer, rhinomat, scale):
-   pass
+
+    curve_data = context.blend_data.curves.new(Name, type="CURVE")
+
+    curve_data.dimensions = '3D'
+    curve_data.resolution_u = 2
+
+    CONVERT[type(og)](og, curve_data, scale)
+
+    #print("Curve type: {}".format(speckle_curve["type"]))
+
+    add_curve(context, n, Name, Id, curve_data, layer, rhinomat)
+
+def add_curve(context, name, origname, id, cdata, layer, rhinomat):
+
+    cdata.materials.append(rhinomat)
+
+    ob = utils.get_iddata(context.blend_data.objects, id, origname, cdata)
+    # Rhino data is all in world space, so add object at 0,0,0
+    ob.location = (0.0, 0.0, 0.0)
+    try:
+        layer.objects.link(ob)
+    except Exception:
+        pass

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -119,7 +119,7 @@ def read_3dm(context, filepath, import_hidden, import_views, import_named_views,
             continue
         convert_rhino_object = converters.RHINO_TYPE_TO_IMPORT[og.ObjectType]
         attr = ob.Attributes
-        if not attr.Visible:
+        if not attr.Visible and not import_hidden:
             continue
         if attr.Name == "" or attr.Name is None:
             n = str(og.ObjectType).split(".")[1]+" " + str(attr.Id)


### PR DESCRIPTION
# Adds basic support for importing Rhino curves

As the title says, however, due to limitations with `rhino3dm`, Polycurves are not supported at the moment.

It's not a totally clean PR as it accidentally includes PR #32 ...

## detailed explanation
* Polylines and Lines are imported as Blender curves with a `POLY` spline type.
* NurbsCurves are imported as Blender curves with a `NURBS` spline type. An exact match between the curve shape in Rhino and the curve shape in Blender is not guaranteed. This needs some further testing.
* Polycurves are not yet supported.
* Arcs are not yet supported.

