### PR TITLE
Dependency Installation Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ This code is currently being written directly for Blender 2.80, even though it i
 The add-on will automatically install all dependencies in user-writable locations.
 
 Installation
-=======================
+============
 
+* Note on MacOS some preparations need to be done, see next section
 * Start Blender 2.80
 * In top menu press Edit > User Preferences...
 * Select the section Add-ons
@@ -23,3 +24,17 @@ Installation
 * Restart Blender.
 
 If you just now downloaded Blender 2.80 you can either use the operator search menu by pressing F3, or through File > Import.
+
+Preparation steps MacOS
+=======================
+* Blender 2.80 installed in Applications. For newer versions adapt the path according version
+* open a terminal
+* type `cd /Applications/Blender.app/Contents/Resources/2.80/python`
+    * first we remove the old pip in the site-packages (if any):
+      * `rm -rf ./lib/python3.7/site-packages/pip*`
+    * now we install `pip3.7`
+      * `./bin/python3.7m ./lib/python3.7/ensurepip`
+    * check `pip3.7` (and `pip3`) are installed in the expected location
+      * `ls ./bin`
+      * ensure listing gives `pip3`
+    * you should now be ready to install the `import_3dm` add-on as per instructions in the `Installation` section.

--- a/README.md
+++ b/README.md
@@ -9,13 +9,9 @@ Requirements
 
 This code is currently being written directly for Blender 2.80, even though it is still pre-beta. In general the latest 2.80 build for your platform from [Blender Builder](https://builder.blender.org/download/) should be fine.
 
-The latest `rhino3dm.py` module is also required. It may be that sometimes master of `rhino3dm.py` is required, but not yet uploaded to PyPi. If you want to keep up-to-date the best bet is to build `rhino3dm.py` from source.
+The add-on will automatically install all dependencies in user-writable locations.
 
-When both `import_3dm` and `rhino3dm.py` are becoming more stable we'll start tagging this repository and putting up proper releases.
-
-Until then things can, and will, break.
-
-Installation on Windows
+Installation
 =======================
 
 * Start Blender 2.80
@@ -25,43 +21,4 @@ Installation on Windows
 * Browse to where you saved the zip file, select it and press the Install add-on from file button in the top right of the file browser
 * Done. Probably a good idea to restart Blender.
 
-From version 0.0.4 onward all dependencies will be automatically installed.
-
 If you just now downloaded Blender 2.80 you can either use the operator search menu by pressing F3, or through File > Import.
-
-Installation on Mac OS X
-========================
-
-Install Blender 2.80 and open terminal
---------------------------------------
-* Install Blender 2.80 into Applications
-* open a terminal
-* `cd /Applications/blender.app/Contents/Resources/2.80/python`
-
-Install pip3.7
---------------
-* Using the terminal at the location from the first part
-* Ensure `pip3.7` for Blender is installed properly
-    * first we remove the old pip in the site-packages
-        * `rm -rf lib/python3.7/site-packages/pip*`
-    * now we install `pip3.7`
-        * `./bin/python3.7m lib/python3.7/ensurepip`
-    * check `pip3.7` is now installed in the expected location
-        *  `ls ./bin`
-        * ensure the listing gives `pip3.7`
-
-Install or upgrade rhino3dm.py
--------------------
-* Using the terminal at the location from the first part
-* First install (or upgrade) `rhino3dm.py`
-    * `./bin/pip3.7 install --upgrade --target lib/python3.7 rhino3dm`
-
-Install import_3dm
-------------------
-* Get the correct zip file from https://github.com/jesterKing/import_3dm/releases/latest (the one with import_3dm in the name)
-* Start Blender 2.80
-* In top menu press Edit > User Preferences...
-* Select the section Add-ons
-* In the bottom of that window select Install add-on from file...
-* Browse to where you saved the zip file, select it and press the Install add-on from file button in the top right of the file browser
-* Done. Probably a good idea to restart Blender.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Installation
 * Select the section Add-ons
 * In the bottom of that window select Install add-on from file...
 * Browse to where you saved the zip file, select it and press the Install add-on from file button in the top right of the file browser
-* Done. Probably a good idea to restart Blender.
+* There may be exceptions and warnings, look in the output to see if you need to do anything (note: on Linux you'll most likely will have to run the pip installation manually. The terminal will have the line to run)
+* Restart Blender.
 
 If you just now downloaded Blender 2.80 you can either use the operator search menu by pressing F3, or through File > Import.

--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -24,7 +24,7 @@
 bl_info = {
     "name": "Import Rhinoceros 3D",
     "author": "Nathan 'jesterKing' Letwory, Joel Putnam, Tom Svilans",
-    "version": (0, 0, 4),
+    "version": (0, 0, 5),
     "blender": (2, 80, 0),
     "location": "File > Import > Rhinoceros 3D (.3dm)",
     "description": "This addon lets you import Rhinoceros 3dm files",

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -85,11 +85,22 @@ def install_dependencies():
         # we can add here something like "==0.0.5".
         # for now assume latest available is ok
         rhino3dm_version=""
+
+        pip3 = "pip3"
+        if sys.platform=="darwin":
+            pip3 = os.path.normpath(
+                os.path.join(
+                os.path.dirname(bpy.app.binary_path_python),
+                "..",
+                "bin",
+                pip3
+                )
+            )
             
         # call pip in a subprocess so we don't have to mess
         # with internals. Also, this ensures the Python used to
         # install pip is going to be used
-        res = sprun(["pip3", "install", "--upgrade", "--target", modulespath, "rhino3dm{}".format(rhino3dm_version)])
+        res = sprun([pip3, "install", "--upgrade", "--target", modulespath, "rhino3dm{}".format(rhino3dm_version)])
         if res.returncode!=0:
             print("Please try manually installing rhino3dm with: pip3 install --upgrade --target {} rhino3dm".format(modulespath))
             raise Exception("Failed to install rhino3dm. See console for manual install instruction.")

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -26,6 +26,20 @@ import bpy
 def install_dependencies():
     import sys
     import os
+
+    # set up addons/modules under the user
+    # script path. Here we'll install the
+    # dependencies
+    modulespath = os.path.normpath(
+        os.path.join(
+            bpy.utils.script_path_user(),
+            "addons",
+            "modules"
+        )
+    )
+    if not os.path.exists(modulespath):
+        os.makedirs(modulespath) 
+    
     try:
         try:
             import pip
@@ -45,22 +59,13 @@ def install_dependencies():
                     "..", "lib", pyver, "ensurepip"
                 )
             )
-            res = sprun([bpy.app.binary_path_python, ensurepip])
+            res = sprun([bpy.app.binary_path_python, ensurepip, "--root", modulespath])
 
             if res.returncode == 0:
                 import pip
             else:
                 raise Exception("Failed to install pip.")
 
-        modulespath = os.path.normpath(
-            os.path.join(
-                bpy.utils.script_path_user(),
-                "addons",
-                "modules"
-            )
-        )
-        if not os.path.exists(modulespath):
-           os.makedirs(modulespath) 
         print("Installing rhino3dm to {}... ".format(modulespath)),
 
         try:
@@ -74,17 +79,14 @@ def install_dependencies():
     except:
         raise Exception("Failed to install dependencies. Please make sure you have pip installed.")
 
+# TODO: add update mechanism
 try:
     import rhino3dm as r3d
 except:
     print("Failed to load rhino3dm.")
     from sys import platform
-    if platform == "win32":
-        install_dependencies()
-        import rhino3dm as r3d
-    else:
-        print("Platform {} cannot automatically install dependencies.".format(platform))
-        raise
+    install_dependencies()
+    import rhino3dm as r3d
 
 from . import converters
 

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -22,11 +22,11 @@
 
 import os.path
 import bpy
+import sys
+import os
+import site
 
-def install_dependencies():
-    import sys
-    import os
-
+def modules_path():
     # set up addons/modules under the user
     # script path. Here we'll install the
     # dependencies
@@ -39,12 +39,23 @@ def install_dependencies():
     )
     if not os.path.exists(modulespath):
         os.makedirs(modulespath) 
+
+    # set user modules path at beginning of paths for earlier hit
+    if sys.path[1] != modulespath:
+        sys.path.insert(1, modulespath)
+
+    return modulespath
+
+modules_path()
+
+def install_dependencies():
+    modulespath = modules_path()
     
     try:
+        from subprocess import run as sprun
         try:
             import pip
         except:
-            from subprocess import run as sprun
             print("Installing pip... "),
             pyver = ""
             if sys.platform != "win32":
@@ -59,6 +70,8 @@ def install_dependencies():
                     "..", "lib", pyver, "ensurepip"
                 )
             )
+            # install pip using the user scheme using the Python
+            # version bundled with Blender
             res = sprun([bpy.app.binary_path_python, ensurepip, "--user"])
 
             if res.returncode == 0:
@@ -68,25 +81,35 @@ def install_dependencies():
 
         print("Installing rhino3dm to {}... ".format(modulespath)),
 
-        try:
-            from pip import main as pipmain
-        except:
-            from pip._internal import main as pipmain
-
-        res = pipmain(["install", "--upgrade", "--target", modulespath, "rhino3dm"])
-        if res > 0:
-            raise Exception("Failed to install rhino3dm.")
+        # if we eventually want to pin a certain version
+        # we can add here something like "==0.0.5".
+        # for now assume latest available is ok
+        rhino3dm_version=""
+            
+        # call pip in a subprocess so we don't have to mess
+        # with internals. Also, this ensures the Python used to
+        # install pip is going to be used
+        res = sprun(["pip3", "install", "--upgrade", "--target", modulespath, "rhino3dm{}".format(rhino3dm_version)])
+        if res.returncode!=0:
+            print("Please try manually installing rhino3dm with: pip3 install --upgrade --target {} rhino3dm".format(modulespath))
+            raise Exception("Failed to install rhino3dm. See console for manual install instruction.")
     except:
         raise Exception("Failed to install dependencies. Please make sure you have pip installed.")
+    
 
 # TODO: add update mechanism
 try:
     import rhino3dm as r3d
 except:
-    print("Failed to load rhino3dm.")
-    from sys import platform
-    install_dependencies()
-    import rhino3dm as r3d
+    print("Failed to load rhino3dm, trying to install automatically...")
+    try:
+        install_dependencies()
+        # let user restart Blender, reloading of rhino3dm after automated
+        # install doesn't always work, better to just fail clearly before
+        # that
+        raise Exception("Please restart Blender.")
+    except:
+        raise
 
 from . import converters
 

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -59,7 +59,7 @@ def install_dependencies():
                     "..", "lib", pyver, "ensurepip"
                 )
             )
-            res = sprun([bpy.app.binary_path_python, ensurepip, "--root", modulespath])
+            res = sprun([bpy.app.binary_path_python, ensurepip, "--user"])
 
             if res.returncode == 0:
                 import pip


### PR DESCRIPTION
The add-on should no longer need installation as elevated user.

Amendments were made to work on Linux and MacOS as well.

Caveat: it appears the very latest `rhino3dm` module (0.0.5) doesn't
compile correctly. YMMV.