### PR TITLE
PolyCurve + Arc support

### DIFF
--- a/import_3dm/converters/curve.py
+++ b/import_3dm/converters/curve.py
@@ -89,9 +89,6 @@ def import_arc(rcurve, bcurve, scale):
 
     d = rcurve.Arc.Length * scale
 
-    print(r1)
-    print(r2)
-
     normal = r1.cross(r2)
 
     t1 = normal.cross(r1)

--- a/import_3dm/converters/curve.py
+++ b/import_3dm/converters/curve.py
@@ -138,6 +138,8 @@ def import_arc(rcurve, bcurve, scale):
 
     return arc
 
+CONVERT[r3d.ArcCurve] = import_arc
+
 def import_polycurve(rcurve, bcurve, scale):
 
     for seg in range(rcurve.SegmentCount):


### PR DESCRIPTION
# PolyCurve and Arc support

This PR adds support for importing PolyCurves and a basic conversion for Arcs.

## detailed explanation
* PolyCurves are now supported due to the addition of  `PolyCurve.SegmentCurve()` in `rhino3dm0.6.0`.
* Arcs are imported as NURBS splines with 4 control points. Additional work is needed to make this better + more accurate.
