### PR TITLE
adds support for group import

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,12 @@
 # Title of the PR changeset (Fix certain issue, or Implement/Add feature)
 
-A short description of the changes
+Adds feature to import group structure from rhino file and link objects
 
 ## detailed explanation
-* with bullet list
-* explain the major changes that this PR holds
+* collects all group ids from rhino objects and creates the according collections in Blender
+* has option to recreate nested group hierarchy as collections instead of importing all groups in parallel
+* tested for named and unnamed objects, nested and simple groups, reimporting the same file and reimporting over a previously ungrouped file
+* possible issue that needs to be adressed: since the r3d group ids are simple integers and dont carry a uuid they are not unique and will create unpredictable behaviour when importing another file with same group names
 
 ## fixes / resolves
-Type here the issues that are fixed, i.e. Resolves or Fixes #issuenumber.
-If your PR addresses multiple issues mention each one on a line by its own
-with the proper verb.
+Fixes #7

--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -69,7 +69,7 @@ class Import3dm(Operator, ImportHelper):
         name="Import Hidden Layers",
         description="Import Hidden Layers",
         default=True,
-    )    
+    )
 
     import_views: BoolProperty(
         name="Import standard views.",
@@ -83,12 +83,24 @@ class Import3dm(Operator, ImportHelper):
         default=True,
     )
 
+    import_groups: BoolProperty(
+        name="Import groups.",
+        description="Import groups as collections.",
+        default=True,
+    )
+
+    import_nested_groups: BoolProperty(
+        name="handle nested groups.",
+        description="Recreate nested group hierarchy as collections.",
+        default=False,
+    )
+
 
     update_materials: BoolProperty(
         name="Update materials.",
         description="Update existing materials. Otherwise, create new materials if existing ones are found.",
         default=True,
-    )          
+    )
 
 #    type: EnumProperty(
 #        name="Example Enum",
@@ -101,7 +113,7 @@ class Import3dm(Operator, ImportHelper):
 #    )
 
     def execute(self, context):
-        return read_3dm(context, self.filepath, self.import_hidden, self.import_views, self.import_named_views, self.update_materials, self.import_hidden_layers)
+        return read_3dm(context, self.filepath, self.import_hidden, self.import_views, self.import_named_views, self.import_groups, self.import_nested_groups, self.update_materials, self.import_hidden_layers)
 
 # Only needed if you want to add into a dynamic menu
 def menu_func_import(self, context):

--- a/import_3dm/converters/__init__.py
+++ b/import_3dm/converters/__init__.py
@@ -27,6 +27,7 @@ from .layers import handle_layers
 from .render_mesh import import_render_mesh
 from .curve import import_curve
 from .views import handle_views
+from .groups import handle_groups
 
 '''
 Dictionary mapping between the Rhino file types and importer functions

--- a/import_3dm/converters/groups.py
+++ b/import_3dm/converters/groups.py
@@ -1,0 +1,80 @@
+# MIT License
+
+# Copyright (c) 2018-2019 Nathan Letwory, Joel Putnam, Tom Svilans
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from . import utils
+
+def handle_groups(context,attr,toplayer, last_obj, import_nested_groups):
+
+    #if selected, check if object is group member
+    if attr.GroupCount>0:
+        group_list = attr.GetGroupList()
+        print(group_list)
+        group_prefix = "Group_"
+        group_col_id = "Groups"
+
+        #if theres still no main collection to hold all groups, create one and link it to toplayer
+        if not group_col_id in context.blend_data.collections:
+                gcol = context.blend_data.collections.new(name=group_col_id)
+                toplayer.children.link(gcol)
+
+
+        #loop through the group ids that the object belongs to, build a hierarchy and link the object to the lowest one
+        for index, gid in enumerate(group_list):
+            #build child group id and check if it exists, if it doesnt, add a new collection, if it does, use the existing one
+            child_id = group_prefix + str(gid)
+
+            if not child_id in context.blend_data.collections:
+                ccol = context.blend_data.collections.new(name=child_id)
+            else:
+                ccol = context.blend_data.collections[child_id]
+
+            #same as before, if there is a parent group, use it. if not, or if nesting is disable default to main group collection
+            try:
+                parent_id = group_prefix + str(group_list[index+1])
+            except Exception:
+                parent_id = None
+
+            if parent_id==None or not import_nested_groups:
+                parent_id = group_col_id
+
+            if not parent_id in context.blend_data.collections:
+                pcol = context.blend_data.collections.new(name=parent_id)
+            else:
+                pcol = context.blend_data.collections[parent_id]
+
+
+            #if child group is not yet linked to its parent, do so
+            if not child_id in pcol.children:
+                pcol.children.link(ccol)
+
+
+            #if were in the lowest group of the hierarchy and nesting is enabled, link the object to the collection
+            if index==0 and import_nested_groups:
+                try:
+                    ccol.objects.link(last_obj)
+                except Exception:
+                    pass
+            #if nested import is disabled, link to every collection it belongs to
+            elif not import_nested_groups:
+                try:
+                    ccol.objects.link(last_obj)
+                except Exception:
+                    pass

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -38,7 +38,7 @@ def modules_path():
         )
     )
     if not os.path.exists(modulespath):
-        os.makedirs(modulespath) 
+        os.makedirs(modulespath)
 
     # set user modules path at beginning of paths for earlier hit
     if sys.path[1] != modulespath:
@@ -50,7 +50,7 @@ modules_path()
 
 def install_dependencies():
     modulespath = modules_path()
-    
+
     try:
         from subprocess import run as sprun
         try:
@@ -96,7 +96,7 @@ def install_dependencies():
                 pip3
                 )
             )
-            
+
         # call pip in a subprocess so we don't have to mess
         # with internals. Also, this ensures the Python used to
         # install pip is going to be used
@@ -106,7 +106,7 @@ def install_dependencies():
             raise Exception("Failed to install rhino3dm. See console for manual install instruction.")
     except:
         raise Exception("Failed to install dependencies. Please make sure you have pip installed.")
-    
+
 
 # TODO: add update mechanism
 try:
@@ -124,7 +124,7 @@ except:
 
 from . import converters
 
-def read_3dm(context, filepath, import_hidden, import_views, import_named_views, update_materials=False, import_hidden_layers=False):
+def read_3dm(context, filepath, import_hidden, import_views, import_named_views, import_groups, import_nested_groups, update_materials=False, import_hidden_layers=False):
     top_collection_name = os.path.splitext(os.path.basename(filepath))[0]
     if top_collection_name in context.blend_data.collections.keys():
         toplayer = context.blend_data.collections[top_collection_name]
@@ -132,10 +132,10 @@ def read_3dm(context, filepath, import_hidden, import_views, import_named_views,
         toplayer = context.blend_data.collections.new(name=top_collection_name)
 
     model = r3d.File3dm.Read(filepath)
-    
+
     # Get proper scale for conversion
-    scale = r3d.UnitSystem.UnitScale(model.Settings.ModelUnitSystem, r3d.UnitSystem.Meters) / context.scene.unit_settings.scale_length    
-    
+    scale = r3d.UnitSystem.UnitScale(model.Settings.ModelUnitSystem, r3d.UnitSystem.Meters) / context.scene.unit_settings.scale_length
+
     layerids = {}
     materials = {}
 
@@ -184,6 +184,17 @@ def read_3dm(context, filepath, import_hidden, import_views, import_named_views,
         layer = layerids[str(layeruuid)][1]
 
         convert_rhino_object(og, context, n, attr.Name, attr.Id, layer, rhinomat, scale)
+
+
+        #last_obj=context.active_object #doesnt work for whatever reason (not linked to scene yet??)
+        #fetch last created oject by its r3d guid
+        try:
+            last_obj=[obj for obj in context.blend_data.objects if obj.get('rhid', None) == str(attr.Id)]
+        except Exception:
+            return
+
+        if import_groups:
+            converters.handle_groups(context,attr,toplayer,last_obj[0],import_nested_groups)
 
     # finally link in the container collection (top layer) into the main
     # scene collection.


### PR DESCRIPTION
# Adds feature group import

Adds feature to import group structure from rhino file and link objects

## detailed explanation
* collects all group ids from rhino objects and creates the according collections in Blender
* has option to recreate nested group hierarchy as collections instead of importing all groups in parallel
* tested for named and unnamed objects, nested and simple groups, reimporting the same file and reimporting over a previously ungrouped file
* possible issue that needs to be adressed: since the r3d group ids are simple integers and dont carry a uuid they are not unique and will create unpredictable behaviour when importing another file with same group names

## fixes / resolves
Fixes #7
