### PR TITLE
groups all layer collections into one main "Layers" collection

### DIFF
--- a/import_3dm/converters/layers.py
+++ b/import_3dm/converters/layers.py
@@ -32,6 +32,15 @@ def handle_layers(context, model, toplayer, layerids, materials, update, import_
     Update materials dictionary with materials created
     for layer color.
     """
+    #setup main container to hold all layer collections
+    layer_col_id="Layers"
+    if not layer_col_id in context.blend_data.collections:
+            layer_col = context.blend_data.collections.new(name=layer_col_id)
+            try:
+                toplayer.children.link(layer_col)
+            except Exception:
+                pass
+
     # build lookup table for LayerTable index
     # from GUID, create collection for each
     # layer
@@ -62,6 +71,6 @@ def handle_layers(context, model, toplayer, layerids, materials, update, import_
         # or to the top collection if no parent layer was found
         else:
             try:
-                toplayer.children.link(layerids[str(l.Id)][1])
+                layer_col.children.link(layerids[str(l.Id)][1])
             except Exception:
                 pass


### PR DESCRIPTION
# partial fix to #42 

groups all layer collections into one main "Layers" collection to make file easier to navigate in outliner

## detailed explanation
*adds new collection "Layers"
*links "Layers" to toplayer collection
*links all parent layers to new "Layers" collection (children are still linked to their parents)

## fixes / resolves
partially Fixes #42
