### PR TITLE
Read3dm settings

### DIFF
--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -59,7 +59,7 @@ class Import3dm(Operator, ImportHelper):
 
     # List of operator properties, the attributes will be assigned
     # to the class instance from the operator settings before calling.
-    import_hidden: BoolProperty(
+    import_hidden_objects: BoolProperty(
         name="Import Hidden Geometry",
         description="Import Hidden Geometry",
         default=True,
@@ -101,7 +101,15 @@ class Import3dm(Operator, ImportHelper):
 #    )
 
     def execute(self, context):
-        return read_3dm(context, self.filepath, self.import_hidden, self.import_views, self.import_named_views, self.update_materials, self.import_hidden_layers)
+        options = {
+            "filepath":self.filepath,
+            "import_views":self.import_views,
+            "import_named_views":self.import_named_views,
+            "update_materials":self.update_materials,
+            "import_hidden_objects":self.import_hidden_objects,
+            "import_hidden_layers":self.import_hidden_layers,
+        }
+        return read_3dm(context, options)
 
 # Only needed if you want to add into a dynamic menu
 def menu_func_import(self, context):

--- a/import_3dm/converters/curve.py
+++ b/import_3dm/converters/curve.py
@@ -127,7 +127,7 @@ def import_arc(rcurve, bcurve, scale):
 
     '''
     print("ARC")
-    print("   StartPoint:", rcurve.Arc.StartPoint)
+    print("    StartPoint:", rcurve.Arc.StartPoint)
     print("      EndPoint:", rcurve.Arc.EndPoint)
     print("        Center:", rcurve.Arc.Center)
     print("        Radius:", rcurve.Radius)


### PR DESCRIPTION
# Update read_3dm()  to take options dict

The function arguments are growing in count. Anticipating this as well as more import options, this updates `read_3dm()` to take a `dict` instead which contains all import options.

## detailed explanation
* Creates dict in `Import3dm.execute()` and passes it to `read_3dm()`
* Parses options dict in `read_3dm()` and assigns default values if keys are not found.

## fixes / resolves
Fixes an expanding argument list for `read_3dm()`, improving legibility.
