### PR TITLE
Material source support

### DIFF
--- a/import_3dm/converters/curve.py
+++ b/import_3dm/converters/curve.py
@@ -149,7 +149,7 @@ def import_polycurve(rcurve, bcurve, scale):
 
 CONVERT[r3d.PolyCurve] = import_polycurve
 
-def import_curve(og,context, n, Name, Id, layer, rhinomat, scale):
+def import_curve(og,context, n, Name, Id, layer, rhinomat, rhinocolor, scale):
 
     if type(og) in CONVERT.keys():
 
@@ -162,7 +162,7 @@ def import_curve(og,context, n, Name, Id, layer, rhinomat, scale):
 
         add_curve(context, n, Name, Id, curve_data, layer, rhinomat)
 
-def add_curve(context, name, origname, id, cdata, layer, rhinomat):
+def add_curve(context, name, origname, id, cdata, layer, rhinomat, rhinocolor):
 
     cdata.materials.append(rhinomat)
 

--- a/import_3dm/converters/layers.py
+++ b/import_3dm/converters/layers.py
@@ -41,6 +41,7 @@ def handle_layers(context, model, toplayer, layerids, materials, update, import_
         lcol = utils.get_iddata(context.blend_data.collections, l.Id, l.Name, None)
         layerids[str(l.Id)] = (lid, lcol)
         utils.tag_data(layerids[str(l.Id)][1], l.Id, l.Name)
+        '''
         matname = l.Name + "+" + str(l.Id)
         if matname not in materials:
             laymat = utils.get_iddata(context.blend_data.materials, l.Id, l.Name, None)
@@ -50,6 +51,7 @@ def handle_layers(context, model, toplayer, layerids, materials, update, import_
 	            principled = PrincipledBSDFWrapper(laymat, is_readonly=False)
 	            principled.base_color = (r/255.0, g/255.0, b/255.0)
             materials[matname] = laymat
+        '''
     # second pass so we can link layers to each other
     for l in model.Layers:
         # link up layers to their parent layers

--- a/import_3dm/converters/material.py
+++ b/import_3dm/converters/material.py
@@ -27,6 +27,9 @@ import rhino3dm as r3d
 from bpy_extras.node_shader_utils import PrincipledBSDFWrapper
 from . import utils
 
+### default Rhino material name
+DEFAULT_RHINO_MATERIAL = "Rhino Default Material"
+
 #### material hashing functions
 
 _black = (0, 0, 0, 255)

--- a/import_3dm/converters/render_mesh.py
+++ b/import_3dm/converters/render_mesh.py
@@ -24,7 +24,7 @@ import rhino3dm as r3d
 from . import utils
 
 
-def add_object(context, name, origname, id, verts, faces, layer, rhinomat):
+def add_object(context, name, origname, id, verts, faces, layer, rhinomat, rhinocolor):
     """
     Add a new object with given mesh data, link to
     collection given by layer
@@ -35,13 +35,14 @@ def add_object(context, name, origname, id, verts, faces, layer, rhinomat):
     ob = utils.get_iddata(context.blend_data.objects, id, origname, mesh)
     # Rhino data is all in world space, so add object at 0,0,0
     ob.location = (0.0, 0.0, 0.0)
+    ob.color = [x/255. for x in rhinocolor]
     try:
         layer.objects.link(ob)
     except Exception:
         pass
 
 
-def import_render_mesh(og, context, n, Name, Id, layer, rhinomat, scale):
+def import_render_mesh(og, context, n, Name, Id, layer, rhinomat, rhinocolor, scale):
     # concatenate all meshes from all (brep) faces,
     # adjust vertex indices for faces accordingly
     # first get all render meshes
@@ -70,4 +71,4 @@ def import_render_mesh(og, context, n, Name, Id, layer, rhinomat, scale):
         fidx = fidx + len(m.Vertices)
         vertices.extend([(m.Vertices[v].X * scale, m.Vertices[v].Y * scale, m.Vertices[v].Z * scale) for v in range(len(m.Vertices))])
     # done, now add object to blender
-    add_object(context, n, Name, Id, vertices, faces, layer, rhinomat)
+    add_object(context, n, Name, Id, vertices, faces, layer, rhinomat, rhinocolor)

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -152,19 +152,22 @@ def read_3dm(context, filepath, import_hidden, import_views, import_named_views,
 
     for ob in model.Objects:
         og = ob.Geometry
+
         if og.ObjectType not in converters.RHINO_TYPE_TO_IMPORT:
             continue
+            
         convert_rhino_object = converters.RHINO_TYPE_TO_IMPORT[og.ObjectType]
         attr = ob.Attributes
+
         if not attr.Visible and not import_hidden:
             continue
+
         if attr.Name == "" or attr.Name is None:
             n = str(og.ObjectType).split(".")[1]+" " + str(attr.Id)
         else:
             n = attr.Name
 
         rhinolayer = model.Layers.FindIndex(attr.LayerIndex)
-
 
         if not rhinolayer.Visible and not import_hidden_layers:
             continue
@@ -183,12 +186,18 @@ def read_3dm(context, filepath, import_hidden, import_views, import_named_views,
         else:
             matname = converters.material_name(rhino_material)
 
+        # Handle object view color
+        if ob.Attributes.ColorSource == r3d.ObjectColorSource.ColorFromLayer:
+            view_color = rhinolayer.Color
+        else:
+            view_color = ob.Attributes.Color
+
         rhinomat = materials[matname]
 
         # Fetch layer
         layer = layerids[str(rhinolayer.Id)][1]
 
-        convert_rhino_object(og, context, n, attr.Name, attr.Id, layer, rhinomat, scale)
+        convert_rhino_object(og, context, n, attr.Name, attr.Id, layer, rhinomat, view_color, scale)
 
     # finally link in the container collection (top layer) into the main
     # scene collection.


### PR DESCRIPTION
# Adds support for render materials

Creates Blender material from Rhino render materials.

## detailed explanation
* Imported objects use the Rhino render material, respecting the material source (object, layer)
* Object display color in Blender is set to the Rhino display color
* Adds the display color to the conversion function calls

## fixes / resolves
Fixes #40 
