### PR TITLE
Object conversion refactor

### DIFF
--- a/import_3dm/converters/__init__.py
+++ b/import_3dm/converters/__init__.py
@@ -38,3 +38,25 @@ RHINO_TYPE_TO_IMPORT = {
     r3d.ObjectType.Mesh : import_render_mesh,
     r3d.ObjectType.Curve : import_curve
 }
+
+
+
+# TODO: Decouple object data creation from object creation
+#       and consolidate object-level conversion.
+
+def convert_object(context, ob, name, layer, rhinomat, scale):
+    """
+    Add a new object with given data, link to
+    collection given by layer
+    """
+
+    data = RHINO_TYPE_TO_IMPORT[ob.Geometry.ObjectType](context, ob, name, scale)
+    data.materials.append(rhinomat)
+
+    ob = utils.get_iddata(context.blend_data.objects, ob.Attributes.Id, ob.Attributes.Name, data)
+    # Rhino data is all in world space, so add object at 0,0,0
+    ob.location = (0.0, 0.0, 0.0)
+    try:
+        layer.objects.link(ob)
+    except Exception:
+        pass

--- a/import_3dm/converters/__init__.py
+++ b/import_3dm/converters/__init__.py
@@ -50,13 +50,24 @@ def convert_object(context, ob, name, layer, rhinomat, scale):
     collection given by layer
     """
 
-    data = RHINO_TYPE_TO_IMPORT[ob.Geometry.ObjectType](context, ob, name, scale)
-    data.materials.append(rhinomat)
+    data = None
 
-    ob = utils.get_iddata(context.blend_data.objects, ob.Attributes.Id, ob.Attributes.Name, data)
+    if ob.Geometry.ObjectType in RHINO_TYPE_TO_IMPORT:
+        data = RHINO_TYPE_TO_IMPORT[ob.Geometry.ObjectType](context, ob, name, scale)
+
+    if data:
+        data.materials.append(rhinomat)
+
+    blender_object = utils.get_iddata(context.blend_data.objects, ob.Attributes.Id, ob.Attributes.Name, data)
+
+    if ob.Geometry.ObjectType == r3d.ObjectType.InstanceReference:
+        # Handle instance
+        pass
+
     # Rhino data is all in world space, so add object at 0,0,0
-    ob.location = (0.0, 0.0, 0.0)
+    blender_object.location = (0.0, 0.0, 0.0)
+
     try:
-        layer.objects.link(ob)
+        layer.objects.link(blender_object)
     except Exception:
         pass

--- a/import_3dm/converters/curve.py
+++ b/import_3dm/converters/curve.py
@@ -96,20 +96,26 @@ def import_polycurve(rcurve, bcurve, scale):
             CONVERT[type(seg)](seg, bcurve, scale)
     '''
 
-CONVERT[r3d.Polycurve] = import_polycurve
+CONVERT[r3d.PolyCurve] = import_polycurve
 
 
-def import_curve(og,context, n, Name, Id, layer, rhinomat, scale):
+def import_curve(context, ob, name, scale):
 
-    curve_data = context.blend_data.curves.new(Name, type="CURVE")
+    og = ob.Geometry
+    oa = ob.Attributes
+
+    curve_data = context.blend_data.curves.new(n, type="CURVE")
 
     curve_data.dimensions = '3D'
     curve_data.resolution_u = 2
 
     CONVERT[type(og)](og, curve_data, scale)
 
-    add_curve(context, n, Name, Id, curve_data, layer, rhinomat)
+    return curve_data
 
+    #add_curve(context, n, Name, Id, curve_data, layer, rhinomat)
+
+'''
 def add_curve(context, name, origname, id, cdata, layer, rhinomat):
 
     cdata.materials.append(rhinomat)
@@ -122,3 +128,4 @@ def add_curve(context, name, origname, id, cdata, layer, rhinomat):
         layer.objects.link(ob)
     except Exception:
         pass
+'''

--- a/import_3dm/converters/curve.py
+++ b/import_3dm/converters/curve.py
@@ -104,7 +104,7 @@ def import_curve(context, ob, name, scale):
     og = ob.Geometry
     oa = ob.Attributes
 
-    curve_data = context.blend_data.curves.new(n, type="CURVE")
+    curve_data = context.blend_data.curves.new(name, type="CURVE")
 
     curve_data.dimensions = '3D'
     curve_data.resolution_u = 2

--- a/import_3dm/converters/render_mesh.py
+++ b/import_3dm/converters/render_mesh.py
@@ -23,7 +23,7 @@
 import rhino3dm as r3d
 from . import utils
 
-
+'''
 def add_object(context, name, origname, id, verts, faces, layer, rhinomat):
     """
     Add a new object with given mesh data, link to
@@ -39,12 +39,15 @@ def add_object(context, name, origname, id, verts, faces, layer, rhinomat):
         layer.objects.link(ob)
     except Exception:
         pass
+'''
 
-
-def import_render_mesh(og, context, n, Name, Id, layer, rhinomat, scale):
+def import_render_mesh(context, ob, name, scale):
     # concatenate all meshes from all (brep) faces,
     # adjust vertex indices for faces accordingly
     # first get all render meshes
+    og = ob.Geometry
+    oa = ob.Attributes
+
     if og.ObjectType == r3d.ObjectType.Extrusion:
         msh = [og.GetMesh(r3d.MeshType.Any)]
     elif og.ObjectType == r3d.ObjectType.Mesh:
@@ -69,5 +72,11 @@ def import_render_mesh(og, context, n, Name, Id, layer, rhinomat, scale):
 
         fidx = fidx + len(m.Vertices)
         vertices.extend([(m.Vertices[v].X * scale, m.Vertices[v].Y * scale, m.Vertices[v].Z * scale) for v in range(len(m.Vertices))])
+    
+    mesh = context.blend_data.meshes.new(name=name)
+    mesh.from_pydata(vertices, [], faces)
+
     # done, now add object to blender
-    add_object(context, n, Name, Id, vertices, faces, layer, rhinomat)
+    
+    return mesh
+    #add_object(context, n, Name, Id, vertices, faces, layer, rhinomat)

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -151,16 +151,17 @@ def read_3dm(context, filepath, import_hidden, import_views, import_named_views,
 
     for ob in model.Objects:
         og = ob.Geometry
+
+        # Skip unsupported object types early
         if og.ObjectType not in converters.RHINO_TYPE_TO_IMPORT:
             continue
-        convert_rhino_object = converters.RHINO_TYPE_TO_IMPORT[og.ObjectType]
+
+        #convert_rhino_object = converters.RHINO_TYPE_TO_IMPORT[og.ObjectType]
+        
+        # Check object and layer visibility
         attr = ob.Attributes
         if not attr.Visible and not import_hidden:
             continue
-        if attr.Name == "" or attr.Name is None:
-            n = str(og.ObjectType).split(".")[1]+" " + str(attr.Id)
-        else:
-            n = attr.Name
 
         if attr.LayerIndex != -1:
             rhinolayer = model.Layers[attr.LayerIndex]
@@ -168,9 +169,18 @@ def read_3dm(context, filepath, import_hidden, import_views, import_named_views,
             rhinolayer = model.Layers[0]
 
         if not rhinolayer.Visible and not import_hidden_layers:
-            print("Skipping hidden layer again.")
             continue
 
+        # Create object name
+        if attr.Name == "" or attr.Name is None:
+            n = str(og.ObjectType).split(".")[1]+" " + str(attr.Id)
+        else:
+            n = attr.Name
+
+
+        # TODO: Move these lines to convert_rhino_object()
+
+        # Get object material
         matname = None
         if attr.MaterialIndex != -1:
             matname = converters.material_name(model.Materials[attr.MaterialIndex])
@@ -183,7 +193,9 @@ def read_3dm(context, filepath, import_hidden, import_views, import_named_views,
             rhinomat = materials[rhinomatname]
         layer = layerids[str(layeruuid)][1]
 
-        convert_rhino_object(og, context, n, attr.Name, attr.Id, layer, rhinomat, scale)
+        converters.convert_object(context, ob, n, layer, rhinomat, scale)
+
+        #convert_rhino_object(og, context, n, attr.Name, attr.Id, layer, rhinomat, scale)
 
     # finally link in the container collection (top layer) into the main
     # scene collection.


### PR DESCRIPTION
# Object conversion refactor

Conversion functions are written more modularly, since code was being repeated, and the creation of objects and object data was too intertwined. 

## detailed explanation
* Object conversion now happens outside of main `read_3dm()` function
* Object and object data creation are separated. Object creation is now done in one place, instead of in different places (`import_curve` and `import_render_mesh`) 
* Object data conversion functions now return the Blender object data
* **!!! This changes several functions !!!**
