### PR TITLE
ob.Attributes.Color doesnt exist, changed to .ObjectColor

### DIFF
--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -219,7 +219,7 @@ def read_3dm(context, options):
         if ob.Attributes.ColorSource == r3d.ObjectColorSource.ColorFromLayer:
             view_color = rhinolayer.Color
         else:
-            view_color = ob.Attributes.Color
+            view_color = ob.Attributes.ObjectColor
 
         rhinomat = materials[matname]
 


### PR DESCRIPTION
ob.Attributes.Color doesnt exist, changed to .ObjectColor

When the color is not set by the layer color, it raises an error. According to bnd_3dm_attributes.cpp/h the color then is stored under ObjectColor. 

