### PR TITLE
fixes broken group import…

### DIFF
--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -86,7 +86,7 @@ class Import3dm(Operator, ImportHelper):
     import_groups: BoolProperty(
         name="Import Groups.",
         description="Import groups as collections.",
-        default=True,
+        default=False,
     )
 
     import_nested_groups: BoolProperty(

--- a/import_3dm/converters/groups.py
+++ b/import_3dm/converters/groups.py
@@ -21,12 +21,10 @@
 # SOFTWARE.
 from . import utils
 
-def handle_groups(context,attr,toplayer, last_obj, import_nested_groups):
-
-    #if selected, check if object is group member
+def handle_groups(context,attr,toplayer, import_nested_groups):
+    #check if object is member of one or more groups
     if attr.GroupCount>0:
         group_list = attr.GetGroupList()
-        print(group_list)
         group_prefix = "Group_"
         group_col_id = "Groups"
 
@@ -65,16 +63,22 @@ def handle_groups(context,attr,toplayer, last_obj, import_nested_groups):
             if not child_id in pcol.children:
                 pcol.children.link(ccol)
 
+            #get the last create blender object by its id
+            last_obj=None
+            for o in context.blend_data.objects:
+                if o.get('rhid', None) == str(attr.Id):
+                    last_obj=o
 
-            #if were in the lowest group of the hierarchy and nesting is enabled, link the object to the collection
-            if index==0 and import_nested_groups:
-                try:
-                    ccol.objects.link(last_obj)
-                except Exception:
-                    pass
-            #if nested import is disabled, link to every collection it belongs to
-            elif not import_nested_groups:
-                try:
-                    ccol.objects.link(last_obj)
-                except Exception:
-                    pass
+            if last_obj:
+                #if were in the lowest group of the hierarchy and nesting is enabled, link the object to the collection
+                if index==0 and import_nested_groups:
+                    try:
+                        ccol.objects.link(last_obj)
+                    except Exception:
+                        pass
+                #if nested import is disabled, link to every collection it belongs to
+                elif not import_nested_groups:
+                    try:
+                        ccol.objects.link(last_obj)
+                    except Exception:
+                        pass

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -219,7 +219,7 @@ def read_3dm(context, options):
         if ob.Attributes.ColorSource == r3d.ObjectColorSource.ColorFromLayer:
             view_color = rhinolayer.Color
         else:
-            view_color = ob.Attributes.Color
+            view_color = ob.Attributes.ObjectColor
 
         rhinomat = materials[matname]
 
@@ -235,16 +235,8 @@ def read_3dm(context, options):
 
         #convert_rhino_object(og, context, n, attr.Name, attr.Id, layer, rhinomat, scale)
 
-
-        #last_obj=context.active_object #doesnt work for whatever reason (not linked to scene yet??)
-        #fetch last created oject by its r3d guid
-        try:
-            last_obj=[obj for obj in context.blend_data.objects if obj.get('rhid', None) == str(attr.Id)]
-        except Exception:
-            return
-
         if import_groups:
-            converters.handle_groups(context,attr,toplayer,last_obj[0],import_nested_groups)
+            converters.handle_groups(context,attr,toplayer,import_nested_groups)
 
     if import_instances:
         converters.populate_instance_definitions(context, model, toplayer, "Instance Definitions")


### PR DESCRIPTION
Fixes broken group import after merge of several branches, sets default merge option to false

Fetching the last created object from blend_data.objects by its rhid-tag caused an index-out-of-range error. 

## detailed explanation
*corrected the faulty behaviour
*relocated the code to fetch the last object within the import method
*set default import option for groups and nested groups to false
*tested possible combinations group import on/off with groups in file/ no groups

.
