### PR TITLE
fixed type mismatch in importer (uuid vs str)

### DIFF
--- a/import_3dm/converters/instances.py
+++ b/import_3dm/converters/instances.py
@@ -77,11 +77,12 @@ def populate_instance_definitions(context, model, toplayer, layername):
         objectids=idef.GetObjectIds()
 
         for ob in context.blend_data.objects:
-            if ob.get('rhid',None) in objectids:
-                try:
-                    parent.objects.link(ob)
-                except Exception:
-                    pass
+            for uuid in objectids:
+                if ob.get('rhid',None) == str(uuid):
+                    try:
+                        parent.objects.link(ob)
+                    except Exception:
+                        pass
 
 
 


### PR DESCRIPTION
a type mismatch in the populate_instance_definitions() method caused the instance definition geometry not to be assigned properly to their definition collections

## detailed explanation
*the importer now casts the uuid to str() before comparing it to blenders 'rhid'-tag