### PR TITLE
Bug fixes, support for rhino3dm-0.10.0

### DIFF
--- a/import_3dm/converters/__init__.py
+++ b/import_3dm/converters/__init__.py
@@ -22,7 +22,8 @@
 
 import rhino3dm as r3d
 
-from .material import handle_materials, material_name
+
+from .material import handle_materials, material_name, DEFAULT_RHINO_MATERIAL
 from .layers import handle_layers
 from .render_mesh import import_render_mesh
 from .curve import import_curve

--- a/import_3dm/converters/curve.py
+++ b/import_3dm/converters/curve.py
@@ -65,7 +65,7 @@ def import_polyline(rcurve, bcurve, scale):
 
     return polyline
 
-CONVERT[r3d.Polylinecurve] = import_polyline
+CONVERT[r3d.PolylineCurve] = import_polyline
 
 def import_nurbs_curve(rcurve, bcurve, scale):
 

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -169,7 +169,7 @@ def read_3dm(context, options):
 
     # Handle layers
     converters.handle_layers(context, model, toplayer, layerids, materials, update_materials, import_hidden_layers)
-    materials[converters.material.DEFAULT_RHINO_MATERIAL] = None
+    materials[converters.DEFAULT_RHINO_MATERIAL] = None
 
     #build skeletal hierarchy of instance definitions as collections (will be populated by object importer)
     if import_instances:
@@ -181,7 +181,7 @@ def read_3dm(context, options):
 
         # Skip unsupported object types early
         if og.ObjectType not in converters.RHINO_TYPE_TO_IMPORT and og.ObjectType != r3d.ObjectType.InstanceReference:
-            print("Unsupported object type... ")
+            print("Unsupported object type: {}".format(og.ObjectType))
             continue
 
         #convert_rhino_object = converters.RHINO_TYPE_TO_IMPORT[og.ObjectType]


### PR DESCRIPTION
# Bug fixes, support for rhino3dm-0.10.0

Fixes a couple of bugs from previous rhino3dm versions.

## detailed explanation
* Changes `Polylinecurve' to `PolylineCurve`
* Fixes reference to `converters.material.DEFAULT_RHINO_MATERIAL`
* Prints the object type when encountering an unsupported type.

## fixes / resolves
* Changes `Polylinecurve' to `PolylineCurve`
* Fixes reference to `converters.material.DEFAULT_RHINO_MATERIAL`
