### PR TITLE
Allowing multiple 3dm file imports

### DIFF
--- a/import_3dm/converters/layers.py
+++ b/import_3dm/converters/layers.py
@@ -40,6 +40,9 @@ def handle_layers(context, model, toplayer, layerids, materials, update, import_
                 toplayer.children.link(layer_col)
             except Exception:
                 pass
+    else:
+        #If "Layers" collection is in place, we assume the plugin had imported 3dm before
+        layer_col = context.blend_data.collections[layer_col_id]
 
     # build lookup table for LayerTable index
     # from GUID, create collection for each


### PR DESCRIPTION
This addresses the bug that ignores imports when there's an existing 3dm import in place (or, if "Layers" collection exists in scene, subsequent imports fails.)

Ref: #80