### PR TITLE
Linked Blocks

### DIFF
--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -154,7 +154,6 @@ class Import3dm(Operator, ImportHelper):
             "create_instance_files":self.create_instance_files,
             "overwrite":self.overwrite,
         }
-
         return read_3dm(context, options, block_toggle = True)
 
     def draw(self, context):

--- a/import_3dm/converters/instances.py
+++ b/import_3dm/converters/instances.py
@@ -44,7 +44,9 @@ def handle_instance_definitions(context, model, toplayer, layername):
             instance_col.hide_render = True
             instance_col.hide_viewport = True
             toplayer.children.link(instance_col)
-
+    
+    instance_properties = []
+    
     for idef in model.InstanceDefinitions:
         idef_col=utils.get_iddata(context.blend_data.collections,idef.Id, idef.Name, None )
 
@@ -52,6 +54,12 @@ def handle_instance_definitions(context, model, toplayer, layername):
             instance_col.children.link(idef_col)
         except Exception:
             pass
+        
+        # Save relevant block data for handling of linked block files        
+        instance_dict = {"Name":idef.Name, "SourceArchive":idef.SourceArchive, "UpdateType":idef.UpdateType}
+        instance_properties.append(instance_dict)
+    
+    return instance_properties
 
 def import_instance_reference(context, ob, iref, name, scale, options):
     #TODO:  insert reduced mesh proxy and hide actual instance in viewport for better performance on large files

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -127,25 +127,6 @@ except:
 
 from . import converters
 
-def clear_memory():
-    bpy.ops.object.select_all(action='SELECT')
-    bpy.ops.object.delete()
-
-    bpy.ops.collection.select_all(action='SELECT')
-    bpy.ops.collection.delete()
-
-    bpy.ops.material.select_all(action='SELECT')
-    bpy.ops.material.delete()
-
-    bpy.ops.text.select_all(action='SELECT')
-    bpy.ops.text.delete()
-
-    bpy.ops.image.select_all(action='SELECT')
-    bpy.ops.image.delete()
-
-    bpy.ops.mesh.select_all(action='SELECT')
-    bpy.ops.mesh.delete()
-
 def read_3dm(context, options, block_toggle):
 
     filepath = options.get("filepath", "")


### PR DESCRIPTION
# Added feature 'Auto-Create Linked Block Files': 

Added an option to the import menu which automatically creates a Blender file for each linked block in the Rhino file. This way the addon can read from these newly created reference files to populate the instance definitions by linking (File > Link). The 'Overwrite' toggle can be enabled to save over existing reference files.

<img width="176" alt="2023-08-03 17_12_51-Blender File View" src="https://github.com/jesterKing/import_3dm/assets/100777338/7a548c85-a129-4219-9c88-a85df37a4827">

## Detailed Explanation
* Added a third argument to read_3dm(). 'block_toggle' allows for recursive calling of the function with different parameters. This is needed to import each block into its own separate Blender file.
* Added 'instance_properties' list to handle_instance_definitions() in 'instances.py'. The list contains dictionaries of name, URL and update type for each block. This is used to determine which blocks need to have reference files created and how to match these reference files to their respective block names when linking.
* Added nuke_everything() in 'read3dm.py'. This is used to clear all objects, materials and textures before importing and saving a reference block file.
* Added link_all() in 'read3dm.py'. This is used to populate all instance definitions that were previously empty, using the newly created reference block files. This only applies to blocks with their block definition type set to 'Linked' in Rhino.
* Since the new option creates and saves new files, it discards everything that hasn't been previously saved. Warning text is included to convey that. If the current project hasn't been saved at all, the import process will abort and ask the user to save first.

## Resolves
Addresses issue "Add support for loading linked blocks from external files" #87
This only implements the mirroring of the Rhino file structure and not the reading from external Rhino files.

## Additional Notes
* It might be feasible to use command line instances of blender to save block files. This would remove the necessity to save the project beforehand. I have yet to explore this option.
* The 'nuke_everything()' function is clunky but gets the job done. I haven't been able to find a better alternative.
* This is my first time coding anything substantial in python so apologies for potential unorthodox code.