### PR TITLE
Improved link file finding

### DIFF
--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -154,7 +154,6 @@ class Import3dm(Operator, ImportHelper):
             "create_instance_files":self.create_instance_files,
             "overwrite":self.overwrite,
         }
-
         return read_3dm(context, options, block_toggle = True)
 
     def draw(self, context):

--- a/import_3dm/converters/instances.py
+++ b/import_3dm/converters/instances.py
@@ -44,7 +44,9 @@ def handle_instance_definitions(context, model, toplayer, layername):
             instance_col.hide_render = True
             instance_col.hide_viewport = True
             toplayer.children.link(instance_col)
-
+    
+    instance_properties = []
+    
     for idef in model.InstanceDefinitions:
         idef_col=utils.get_iddata(context.blend_data.collections,idef.Id, idef.Name, None )
 
@@ -52,6 +54,12 @@ def handle_instance_definitions(context, model, toplayer, layername):
             instance_col.children.link(idef_col)
         except Exception:
             pass
+        
+        # Save relevant block data for handling of linked block files        
+        instance_dict = {"Name":idef.Name, "SourceArchive":idef.SourceArchive, "UpdateType":idef.UpdateType}
+        instance_properties.append(instance_dict)
+    
+    return instance_properties
 
 def import_instance_reference(context, ob, iref, name, scale, options):
     #TODO:  insert reduced mesh proxy and hide actual instance in viewport for better performance on large files

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -127,25 +127,6 @@ except:
 
 from . import converters
 
-def clear_memory():
-    bpy.ops.object.select_all(action='SELECT')
-    bpy.ops.object.delete()
-
-    bpy.ops.collection.select_all(action='SELECT')
-    bpy.ops.collection.delete()
-
-    bpy.ops.material.select_all(action='SELECT')
-    bpy.ops.material.delete()
-
-    bpy.ops.text.select_all(action='SELECT')
-    bpy.ops.text.delete()
-
-    bpy.ops.image.select_all(action='SELECT')
-    bpy.ops.image.delete()
-
-    bpy.ops.mesh.select_all(action='SELECT')
-    bpy.ops.mesh.delete()
-
 def read_3dm(context, options, block_toggle):
 
     filepath = options.get("filepath", "")


### PR DESCRIPTION
Issue: When trying to access the file path of a linked block from a file that has been downloaded from an external source, the file path will be a location on the machine of the person who created that file. This can be fixed by opening the Rhino file and saving it. But it's an extra step that's unintuitive.

Solution: If the file path can't be found locally, comb through sub-directories to locate the linked block file. When found, adjust the 'source_archive' variable accordingly. This is a simplified implementation of how Rhino handles the finding of linked files. https://wiki.mcneel.com/rhino/rhinov5status_filefinding
