### PR TITLE
Add support for annotations and fix curve import

### DIFF
--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -24,7 +24,7 @@
 bl_info = {
     "name": "Import Rhinoceros 3D",
     "author": "Nathan 'jesterKing' Letwory, Joel Putnam, Tom Svilans, Lukas Fertig",
-    "version": (0, 0, 11),
+    "version": (0, 0, 12),
     "blender": (3, 3, 0),
     "location": "File > Import > Rhinoceros 3D (.3dm)",
     "description": "This addon lets you import Rhinoceros 3dm files in Blender 3.3 and later",

--- a/import_3dm/converters/annotation.py
+++ b/import_3dm/converters/annotation.py
@@ -257,6 +257,24 @@ def import_angular(model, dimang, bc, scale):
 CONVERT[r3d.AnnotationTypes.Angular] = import_angular
 
 
+def import_leader(model, dimlead, bc, scale):
+    txt = dimlead.PlainText
+    dimstyle = model.DimStyles.FindId(dimlead.DimensionStyleId)
+    pts = dimlead.Points
+    textptuv = dimlead.GetTextPoint2d(dimstyle, 1.0)
+    textpt = dimlead.Plane.PointAt(textptuv.X, textptuv.Y)
+
+    for i in range(0, len(pts)-1):
+        _populate_line(dimstyle, PartType.DimensionLine, dimlead.Plane, bc, pts[i], pts[i+1], scale)
+
+    _add_arrow(dimstyle, PartType.DimensionLine, dimlead.Plane, bc, pts[0], pts[1], Arrow.Leader)
+
+    return _add_text(dimstyle, dimlead.Plane, bc, textpt, txt, scale)
+
+
+CONVERT[r3d.AnnotationTypes.Leader] = import_leader
+
+
 def import_annotation(context, ob, name, scale, options):
     if not "rh_model" in options:
         return

--- a/import_3dm/converters/annotation.py
+++ b/import_3dm/converters/annotation.py
@@ -158,6 +158,7 @@ def import_dim_linear(model, dimlin, bc, scale):
 
 
 CONVERT[r3d.AnnotationTypes.Aligned] = import_dim_linear
+CONVERT[r3d.AnnotationTypes.Rotated] = import_dim_linear
 
 
 def import_radius(model, dimrad, bc, scale):

--- a/import_3dm/converters/annotation.py
+++ b/import_3dm/converters/annotation.py
@@ -1,0 +1,173 @@
+# MIT License
+
+# Copyright (c) 2024 Nathan Letwory
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import rhino3dm as r3d
+from  . import utils
+
+from mathutils import Vector
+import math
+
+from enum import IntEnum, auto
+import bpy
+
+class PartType(IntEnum):
+    ExtensionLine = auto()
+    DimensionLine = auto()
+
+CONVERT = {}
+
+ARROWS = {}
+
+ARROWS[r3d.ArrowheadTypes.SolidTriangle] = [(0.0, 0.0), (-1.0, 0.25), (-1.0, -0.25)]
+ARROWS[r3d.ArrowheadTypes.Dot] = [
+    (0.5, 0.0), (0.483, 0.129), (0.433, 0.25), (0.353, 0.353), (0.25, 0.433), (0.129, 0.483),
+    (0.0, 0.5), (-0.129, 0.483), (-0.25, 0.433), (-0.353, 0.353), (-0.433, 0.25), (-0.483, 0.129),
+    (-0.5, 0.0), (-0.483, -0.129), (-0.433, -0.25), (-0.353, -0.353), (-0.25, -0.433), (-0.129, -0.483),
+    (0.0, -0.5), (0.129, -0.483), (0.25, -0.433), (0.353, -0.353), (0.433, -0.25), (0.483, -0.129)]
+ARROWS[r3d.ArrowheadTypes.Tick] = [ (-0.46, -0.54), (0.54, 0.46), (0.46, 0.54), (-0.54, -0.46) ]
+ARROWS[r3d.ArrowheadTypes.ShortTriangle] = [(0.0, 0.0), (-0.5, 0.5), (-0.5, -0.5)]
+ARROWS[r3d.ArrowheadTypes.OpenArrow] = [(0.0, 0.0), (-0.707, 0.707), (-0.777, 0.636), (-0.141, 0.0), (-0.777, -0.636), (-0.707, -0.707)]
+ARROWS[r3d.ArrowheadTypes.Rectangle] = [(0.0, 0.0), (-1.0, 0.0), (-1.0, 0.2), (0.0, 0.2)]
+ARROWS[r3d.ArrowheadTypes.LongTriangle] = [(0.0, 0.0), (-1.0, 0.125), (-1.0, -0.125)]
+ARROWS[r3d.ArrowheadTypes.LongerTriangle] = [(0.0, 0.0), (-1.0, 0.0833), (-1.0, -0.0833)]
+
+class Arrow(IntEnum):
+    Arrow1 = auto()
+    Arrow2 = auto()
+    Leader = auto()
+
+def _arrowtype_from_arrow(dimstyle : r3d.DimensionStyle, arrow : Arrow):
+    if arrow == Arrow.Arrow1:
+        return dimstyle.ArrowType1
+    elif arrow == Arrow.Arrow2:
+        return dimstyle.ArrowType2
+    elif arrow == Arrow.Leader:
+        return dimstyle.LeaderArrowType
+
+def _arrowpoints_inside(arrowhead_points, arrow: Arrow, inside):
+    if arrow == Arrow.Arrow1 and inside:
+        arrowhead_points = [(-p[0], -p[1]) for p in arrowhead_points]
+    if arrow == Arrow.Arrow2 and not inside:
+        arrowhead_points = [(-p[0], -p[1]) for p in arrowhead_points]
+    return arrowhead_points
+
+
+def _add_arrow(dimstyle : r3d.DimensionStyle, pt : PartType, plane : r3d.Plane, bc, tip : r3d.Point3d, tail : r3d.Point3d, arrow : Arrow):
+    arrtype = _arrowtype_from_arrow(dimstyle, arrow)
+    arrowhead_points = ARROWS[arrtype]
+    arrowhead = bc.splines.new('POLY')
+    arrowhead.use_cyclic_u = True
+    arrowhead.points.add(len(arrowhead_points)-1)
+    l = r3d.Line(tip, tail)
+    arrowLength = dimstyle.ArrowLength
+    inside = arrowLength * 2 < l.Length
+
+    tip_plane = r3d.Plane(tip, plane.XAxis, plane.YAxis)
+    if arrtype in (r3d.ArrowheadTypes.SolidTriangle, r3d.ArrowheadTypes.ShortTriangle, r3d.ArrowheadTypes.OpenArrow, r3d.ArrowheadTypes.LongTriangle, r3d.ArrowheadTypes.LongerTriangle):
+        if inside and arrow == Arrow.Arrow1:
+            tip_plane = tip_plane.Rotate(math.pi, tip_plane.ZAxis)
+        if not inside and arrow == Arrow.Arrow2:
+            tip_plane = tip_plane.Rotate(math.pi, tip_plane.ZAxis)
+    if arrtype in (r3d.ArrowheadTypes.Rectangle,):
+        if arrow == Arrow.Arrow1:
+            tip_plane = tip_plane.Rotate(math.pi, tip_plane.ZAxis)
+
+    if inside:
+        for i in range(0, len(arrowhead_points)):
+            uv = arrowhead_points[i]
+            p = tip_plane.PointAt(uv[0], uv[1])
+            arrowhead.points[i].co = (p.X, p.Y, p.Z, 1)
+
+
+def _populate_line(dimstyle : r3d.DimensionStyle, pt : PartType, plane : r3d.Plane, bc, pt1 : r3d.Point3d, pt2 : r3d.Point3d, scale : float):
+    line = bc.splines.new('POLY')
+    line.points.add(1)
+
+    # create line between given points
+    rhl = r3d.Line(pt1, pt2)
+    if pt == PartType.ExtensionLine:
+        ext = dimstyle.ExtensionLineExtension
+        offset = dimstyle.ExtensionLineOffset
+        extfr = 1.0 + ext / rhl.Length
+        offsetfr = offset / rhl.Length
+        pt1 = rhl.PointAt(offsetfr)
+        pt2 = rhl.PointAt(extfr)
+
+    pt1 *= scale
+    pt2 *= scale
+
+    line.points[0].co = (pt1.X, pt1.Y, pt1.Z, 1)
+    line.points[1].co = (pt2.X, pt2.Y, pt2.Z, 1)
+
+
+def _add_text(dimstyle : r3d.DimensionStyle, plane : r3d.Plane, bc, pt : r3d.Point3d, txt : str, scale : float):
+    textcurve = bpy.context.blend_data.curves.new(name="annotation_text", type="FONT")
+    textcurve.body = txt
+    textcurve.size = dimstyle.TextHeight * scale
+    textcurve.align_x = 'CENTER'
+    pt *= scale
+    plane = r3d.Plane(pt, plane.XAxis, plane.YAxis)
+    xform = r3d.Transform.PlaneToPlane(r3d.Plane.WorldXY(), plane)
+
+    return (textcurve, utils.matrix_from_xform(xform))
+
+def import_dim_linear(model, dimlin, bc, scale):
+    pts = dimlin.Points
+    txt = dimlin.PlainText
+    dimstyle = model.DimStyles.FindId(dimlin.DimensionStyleId)
+    p = dimlin.Plane
+
+    _populate_line(dimstyle, PartType.ExtensionLine, p, bc, pts["defpt1"], pts["arrowpt1"], scale)
+    _populate_line(dimstyle, PartType.ExtensionLine, p, bc, pts["defpt2"], pts["arrowpt2"], scale)
+    _populate_line(dimstyle, PartType.DimensionLine, p, bc, pts["arrowpt1"], pts["arrowpt2"], scale)
+    _add_arrow(dimstyle, PartType.DimensionLine, p, bc, pts["arrowpt1"], pts["arrowpt2"], Arrow.Arrow1)
+    _add_arrow(dimstyle, PartType.DimensionLine, p, bc, pts["arrowpt2"], pts["arrowpt1"], Arrow.Arrow2)
+
+    return _add_text(dimstyle, p, bc, pts["textpt"], txt, scale)
+
+
+CONVERT[r3d.AnnotationTypes.Aligned] = import_dim_linear
+
+def import_radius(model, dimrad, bc, scale):
+    pass
+
+CONVERT[r3d.AnnotationTypes.Radius] = import_radius
+
+def import_annotation(context, ob, name, scale, options):
+    if not "rh_model" in options:
+        return
+    model = options["rh_model"]
+    if not model:
+        return
+    og = ob.Geometry
+    oa = ob.Attributes
+    text = None
+
+    curve_data = context.blend_data.curves.new(name, type="CURVE")
+    curve_data.dimensions = '2D'
+    curve_data.fill_mode = 'BOTH'
+
+    if og.AnnotationType in CONVERT:
+        text = CONVERT[og.AnnotationType](model, og, curve_data, scale)
+
+    return (curve_data, text)

--- a/import_3dm/converters/annotation.py
+++ b/import_3dm/converters/annotation.py
@@ -198,8 +198,10 @@ def import_angular(model, dimang, bc, scale):
     for line in displines["lines"]:
         _populate_line(dimstyle, PartType.DimensionLine, p, bc, line.From, line.To, scale)
 
-
-    midline = r3d.Line(pts["arrowpt1"], pts["arrowpt2"])
+    # set up midline and angle addition for text plane orientation
+    arrow_line= r3d.Line(pts["arrowpt2"], pts["arrowpt1"])
+    mp = arrow_line.PointAt(0.5)
+    midline = r3d.Line(mp, pts["centerpt"])
     addangle = math.pi * -0.5
     if a > math.pi:
         addangle = math.pi * 1.5

--- a/import_3dm/converters/annotation.py
+++ b/import_3dm/converters/annotation.py
@@ -298,6 +298,16 @@ def import_ordinate(model, dimordinate, bc, scale):
 CONVERT[r3d.AnnotationTypes.Ordinate] = import_ordinate
 
 
+def import_centermark(model, centermark, bc, scale):
+    dimstyle = model.DimStyles.FindId(centermark.DimensionStyleId)
+    lines = centermark.DisplayLines(dimstyle)
+    for line in lines:
+        _populate_line(dimstyle, PartType.DimensionLine, centermark.Plane, bc, line.From, line.To, scale)
+
+
+CONVERT[r3d.AnnotationTypes.CenterMark] = import_centermark
+
+
 def import_annotation(context, ob, name, scale, options):
     if not "rh_model" in options:
         return

--- a/import_3dm/converters/annotation.py
+++ b/import_3dm/converters/annotation.py
@@ -257,6 +257,7 @@ def import_angular(model, dimang, bc, scale):
 
 
 CONVERT[r3d.AnnotationTypes.Angular] = import_angular
+CONVERT[r3d.AnnotationTypes.Angular3pt] = import_angular
 
 
 def import_leader(model, dimlead, bc, scale):

--- a/import_3dm/converters/curve.py
+++ b/import_3dm/converters/curve.py
@@ -131,56 +131,8 @@ def point_to_vector(point) -> Vector:
 
 
 def import_arc(rcurve, bcurve, scale):
-    arc = rcurve.Arc
-
-    angle_degrees = arc.AngleDegrees
-
-    start_angle = arc.StartAngle
-    end_angle = arc.EndAngle
-    sweep_angle = end_angle - start_angle
-
-    blender_arc = bcurve.splines.new('NURBS')
-
-    if angle_degrees <= 90:
-        cv_count = 3
-    elif angle_degrees <= 180:
-        cv_count = 5
-    else:
-        cv_count = 9
-
-    blender_arc.points.add(cv_count - 1 ) # creating spline already has one point, so add N-1 points
-
-    # set curve U properties
-    blender_arc.use_bezier_u = True
-    blender_arc.order_u = 3
-    blender_arc.use_cyclic_u = False
-    blender_arc.use_endpoint_u = True
-
-    # curve, so no V direction
-    blender_arc.order_v = 1
-    blender_arc.resolution_v = 1
-    blender_arc.use_bezier_v = False
-    blender_arc.use_endpoint_v = False
-    blender_arc.use_cyclic_v = False
-
-    points = list()
-    for i in range(cv_count):
-        radian_step = 1.0 / (cv_count - 1)
-        sweep_step = radian_step * sweep_angle
-
-        for i in range(cv_count):
-            p = arc.PointAt(i * sweep_step)
-            points.append(p)
-            if i%2:
-                l = r3d.Line(p, arc.Center)
-                l2 = r3d.Line(points[i-1], points[i-1] + arc.TangentAt(radian_step * (i-1) * arc.AngleRadians))
-                b = r3d.Intersection.LineLine(l, l2)
-                points[i] = l.PointAt(b[1])
-
-    for i in range(cv_count):
-        p = point_to_vector(points[i]) * scale
-        weight = 1 if i%2==0 else 0.70711
-        blender_arc.points[i].co = (p.x, p.y, p.z, weight)
+    nc_arc = rcurve.Arc.ToNurbsCurve()
+    import_nurbs_curve(nc_arc, bcurve, scale, is_arc=True)
 
 
 CONVERT[r3d.ArcCurve] = import_arc

--- a/import_3dm/converters/utils.py
+++ b/import_3dm/converters/utils.py
@@ -24,6 +24,8 @@
 
 import bpy
 import uuid
+import rhino3dm as r3d
+from mathutils import Matrix
 
 from typing import Any, Dict
 
@@ -115,3 +117,12 @@ def get_or_create_iddata(
             theitem = base.new(name=name)
         tag_data(theitem, tag_dict)
     return theitem
+
+def matrix_from_xform(xform : r3d.Transform):
+     m = Matrix(
+            ((xform.M00, xform.M01, xform.M02, xform.M03),
+            (xform.M10, xform.M11, xform.M12, xform.M13),
+            (xform.M20, xform.M21, xform.M22, xform.M23),
+            (xform.M30, xform.M31, xform.M32, xform.M33))
+     )
+     return m

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -88,6 +88,12 @@ def read_3dm(
         print("Failed to import .3dm model: {}".format(filepath))
         return {'CANCELLED'}
 
+
+    # place model in context so we can access it when we need to
+    # find data from different tables, like for instance dimension
+    # styles while working on annotation import.
+    options["rh_model"] = model
+
     toplayer = create_or_get_top_layer(context, filepath)
 
     # Get proper scale for conversion


### PR DESCRIPTION
# Add support for annotations and fix curve import

## annotations

Support annotations, dimensions and text. Text objects for annotations are parented to the linework.

Arrow shapes are provided by rhino3dm

Note that annotations using text fields aren't extrapolated correctly yet, rhino3dm has a bug not providing the correct data. This is logged with rhino3dm developers.

## curves

* curve weights applied correctly, this fixes import of especially arcs and cicrles
* cyclic/non-cyclic fixes
* correct end point usage