### PR TITLE
Update meshes instead of creating new ones

### DIFF
--- a/import_3dm/converters/render_mesh.py
+++ b/import_3dm/converters/render_mesh.py
@@ -65,6 +65,9 @@ def import_render_mesh(context, ob, name, scale, options):
         coords.extend([(m.TextureCoordinates[v].X, m.TextureCoordinates[v].Y) for v in range(len(m.TextureCoordinates))])
 
     mesh = context.blend_data.meshes.new(name=name)
+    tags = utils.create_tag_dict(oa.Id, oa.Name)
+    mesh = utils.get_or_create_iddata(context.blend_data.meshes, tags, None)
+    mesh.clear_geometry()
     mesh.from_pydata(vertices, [], faces)
 
 


### PR DESCRIPTION
# Update mesh data instead of creating new mesh objects

This change updates existing mesh data. It allows to share mesh data across mesh objects. With this change users can add e.g. modifiers of link materials to mesh objects and keep them across updates when the mesh is modified in the Rhino file and re-imported.

## fixes / resolves
- adds rh* tags to mesh
- updates existing mesh data on re-import by clearing and creating the geometry it contains

