### PR TITLE
Blender 4.2 extension

### DIFF
--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -24,7 +24,7 @@
 bl_info = {
     "name": "Import Rhinoceros 3D",
     "author": "Nathan 'jesterKing' Letwory, Joel Putnam, Tom Svilans, Lukas Fertig",
-    "version": (0, 0, 11),
+    "version": (0, 0, 12),
     "blender": (3, 3, 0),
     "location": "File > Import > Rhinoceros 3D (.3dm)",
     "description": "This addon lets you import Rhinoceros 3dm files in Blender 3.3 and later",

--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -33,6 +33,9 @@ bl_info = {
     "category": "Import-Export",
 }
 
+# with extentions bl_info is deleted, we keep a copy of the version
+bl_info_version = bl_info["version"][:]
+
 import bpy
 # ImportHelper is a helper class, defines filename and
 # invoke() function which calls the file selector.
@@ -140,7 +143,7 @@ class Import3dm(Operator, ImportHelper):
 
     def draw(self, _ : bpy.types.Context):
         layout = self.layout
-        layout.label(text="Import .3dm v{}.{}.{}".format(bl_info["version"][0], bl_info["version"][1], bl_info["version"][2]))
+        layout.label(text="Import .3dm v{}.{}.{}".format(bl_info_version[0], bl_info_version[1], bl_info_version[2]))
 
         box = layout.box()
         box.label(text="Visibility")

--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -23,7 +23,7 @@
 
 bl_info = {
     "name": "Import Rhinoceros 3D",
-    "author": "Nathan 'jesterKing' Letwory, Joel Putnam, Tom Svilans, Lukas Fertig",
+    "author": "Nathan 'jesterKing' Letwory, Joel Putnam, Tom Svilans, Lukas Fertig, Bernd Moeller",
     "version": (0, 0, 12),
     "blender": (3, 3, 0),
     "location": "File > Import > Rhinoceros 3D (.3dm)",

--- a/import_3dm/blender_manifest.toml
+++ b/import_3dm/blender_manifest.toml
@@ -1,0 +1,61 @@
+schema_version = "1.0.0"
+
+# Example of manifest file for a Blender extension
+# Change the values according to your extension
+id = "import_3dm"
+version = "0.0.12"
+name = "Import Rhinoceros 3D"
+tagline = "Import Rhinoceros 3dm files in Blender"
+maintainer = "Nathan 'jesterKing' Letwory"
+# Supported types: "add-on", "theme"
+type = "add-on"
+
+# Optional: add-ons can list which resources they will require:
+# * "files" (for access of any filesystem operations)
+# * "network" (for internet access)
+# * "clipboard" (to read and/or write the system clipboard)
+# * "camera" (to capture photos and videos)
+# * "microphone" (to capture audio)
+# permissions = ["files", "network"]
+
+# Optional link to documentation, support, source files, etc
+# website = "http://extensions.blender.org/add-ons/my-example-package/"
+
+# Optional list defined by Blender and server, see:
+# https://docs.blender.org/manual/en/dev/extensions/tags.html
+tags = ["Import-Export",]
+
+blender_version_min = "4.2.0"
+# Optional: maximum supported Blender version
+# blender_version_max = "5.1.0"
+
+# License conforming to https://spdx.org/licenses/ (use "SPDX: prefix)
+# https://docs.blender.org/manual/en/dev/extensions/licenses.html
+license = [
+  "MIT",
+]
+# Optional: required by some licenses.
+# copyright = [
+#   "2002-2024 Developer Name",
+#   "1998 Company Name",
+# ]
+
+# Optional list of supported platforms. If omitted, the extension will be available in all operating systems.
+platforms = ["windows-x64", "macos-arm64", "linux-x86_64"]
+# Other supported platforms: "windows-arm64", "macos-x86_64"
+
+# Optional: bundle 3rd party Python modules.
+# https://docs.blender.org/manual/en/dev/extensions/python_wheels.html
+wheels = [
+  "./wheels/rhino3dm-8.9.0b0-cp311-cp311-macosx_12_0_universal2.whl",
+  "./wheels/rhino3dm-8.9.0b0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+  "./wheels/rhino3dm-8.9.0b0-cp311-cp311-win_amd64.whl",
+]
+
+# Optional: build setting.
+# https://docs.blender.org/manual/en/dev/extensions/command_line_arguments.html#command-line-args-extension-build
+# [build]
+paths_exclude_pattern = [
+  "/.git/",
+  "__pycache__/"
+]

--- a/import_3dm/blender_manifest.toml
+++ b/import_3dm/blender_manifest.toml
@@ -3,7 +3,7 @@ schema_version = "1.0.0"
 # Example of manifest file for a Blender extension
 # Change the values according to your extension
 id = "import_3dm"
-version = "0.0.12"
+version = "0.0.15"
 name = "Import Rhinoceros 3D"
 tagline = "Import Rhinoceros 3dm files in Blender"
 maintainer = "Nathan 'jesterKing' Letwory"


### PR DESCRIPTION
# Necessary changes to create an extension

Blender 4.2 introduced extension (and the related platform). These allow for an easier install process.

## details
The blender manifest mostly just a copy from the on in the docs.

### Python dependencies
For building the plugin, you will need the correct wheels pacakges. To get the wheels packages use the following commands inside the directory of the downloaded repo:
`pip download rhino3dm --dest ./wheels --only-binary=:all: --python-version=3.11`  

### Building the Plugin
`blender --command extension build`

## changes
* adds blender_manifest.toml
* copies version from bl_info as bl_info variable is deleted by blender

