### PR TITLE
Shade smooth fix for blender 4+

### DIFF
--- a/import_3dm/converters/render_mesh.py
+++ b/import_3dm/converters/render_mesh.py
@@ -70,7 +70,7 @@ def import_render_mesh(context, ob, name, scale, options):
     tags = utils.create_tag_dict(oa.Id, oa.Name)
     mesh = utils.get_or_create_iddata(context.blend_data.meshes, tags, None)
     mesh.clear_geometry()
-    mesh.from_pydata(vertices, [], faces)
+    mesh.from_pydata(vertices, [], faces, shade_flat=False)
 
 
     if mesh.loops and len(coords) == len(vertices):

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -193,11 +193,12 @@ def read_3dm(
 
     # finally link in the container collection (top layer) into the main
     # scene collection.
-    try:
-        context.blend_data.scenes[0].collection.children.link(toplayer)
+    context.scene.collection.children.link(toplayer)
+    if bpy.app.version[0] < 4:
         bpy.ops.object.shade_smooth({'selected_editable_objects': toplayer.all_objects})
-    except Exception:
-        pass
+    else:
+        with context.temp_override(selected_editable_objects=toplayer.all_objects):
+            bpy.ops.object.shade_smooth()
 
     converters.cleanup()
 

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -193,7 +193,8 @@ def read_3dm(
 
     # finally link in the container collection (top layer) into the main
     # scene collection.
-    context.scene.collection.children.link(toplayer)
+    if toplayer.name not in context.scene.collection.children:
+        context.scene.collection.children.link(toplayer)
     if bpy.app.version[0] < 4:
         bpy.ops.object.shade_smooth({'selected_editable_objects': toplayer.all_objects})
     else:


### PR DESCRIPTION
# Shade smooth fix for blender 4+

Blender 4 introduced `temp_override()` for context overrides.

## fixes
* silent exception in blender 4+ for shade smooth
* shade smooth applied to meshes during import
* gets active scene from context instead of first scene in blend file