### PR TITLE
pytest setup

### DIFF
--- a/test/pytest.ini_example
+++ b/test/pytest.ini_example
@@ -1,0 +1,4 @@
+[pytest]
+blender-executable = C:/Program Files/Blender Foundation/Blender 4.2/blender.exe
+pythonpath = C:/Users/USERNAME/AppData/Roaming/Blender Foundation/Blender/4.2/extensions/REPOSITORY_NAME/import_3dm
+addopts = --cov "C:/Users/USERNAME/AppData/Roaming/Blender Foundation/Blender/4.2/extensions/REPOSITORY_NAME/import_3dm" --cov-report html

--- a/test/pytest_setup.md
+++ b/test/pytest_setup.md
@@ -1,0 +1,17 @@
+## pytest setup
+
+local python needed  
+install pytest and pytest-blender
+
+install pip in blender (on windows/blender 4.2: ` & 'C:\Program Files\Blender Foundation\Blender 4.2\4.2\python\bin\python.exe' -m ensurepip`)
+then install pytest in blender's python (on windows/blender 4.2: ` & 'C:\Program Files\Blender Foundation\Blender 4.2\4.2\python\bin\python.exe' -m pip install -r test-requirements.txt`)
+
+also see https://pypi.org/project/pytest-blender/ for more info
+
+setup pytest.ini, you can use pytest.ini_example as a starting point, change the file paths accordingly, be aware that this uses the paths blender installs extensions to since blender 4.2
+it also includes options for code coverage, pytest-cov needed in local python and blenders python
+
+
+## unittest setup
+local python needed  
+run `py -m pytest`

--- a/test/test_import_3dm.py
+++ b/test/test_import_3dm.py
@@ -1,0 +1,30 @@
+#!python3
+import pytest
+
+import bpy
+import addon_utils
+
+
+testfiles = [
+    "units/boxes_in_cm.3dm",
+    "units/boxes_in_ft.3dm",
+    "units/boxes_in_in.3dm",
+]
+
+# ############################################################################## #
+# autouse fixtures
+# ############################################################################## #
+
+
+@pytest.fixture(scope="session", autouse=True)
+def enable_addon():
+    addon_utils.enable("import_3dm")
+
+
+# ############################################################################## #
+# test cases
+# ############################################################################## #
+
+@pytest.mark.parametrize("filepath", testfiles)
+def test_create_article(filepath):
+    bpy.ops.import_3dm.some_data(filepath=filepath)


### PR DESCRIPTION
# pytest setup
This PR adds setup instructions for using pytest to test the addon. It relies on pytest-blender.  
It also includes a very simple test case to keep the change small

Test setup assumes that the addon is installed as an extension. Paths need to be adjusted if installed as an addon (pre blender 4.2)

## changes
* adds simple test case using existing test files
* adds pytest setup instructions
