### PR TITLE
Add fix for material link error

### DIFF
--- a/import_3dm/converters/__init__.py
+++ b/import_3dm/converters/__init__.py
@@ -106,6 +106,8 @@ def convert_object(
         blender_object = utils.get_or_create_iddata(context.blend_data.objects, tags, data)
         if link_materials_to == "PREFERENCES":
             link_materials_to = bpy.context.preferences.edit.material_link
+            if link_materials_to == 'OBDATA':
+                link_materials_to = 'DATA'
         for slot in blender_object.material_slots:
             slot.link = link_materials_to
 


### PR DESCRIPTION

![Screenshot 2024-11-23 at 12 52 21](https://github.com/user-attachments/assets/2ecb6d5b-246b-4c4b-bfd6-6dd12f41714b)

Fix for a bug introduced by [PR127](https://github.com/jesterKing/import_3dm/pull/127)

If `bpy.context.preferences.edit.material_link` was set to "OBDATA", it fails. This commit formats the str into "DATA" so `MaterialSlot` can be assigned without throwing the TypeError.

Please refer to:
PreferenceEdit: https://docs.blender.org/api/4.3/bpy.types.PreferencesEdit.html#bpy.types.PreferencesEdit.material_link
Material Slot: https://docs.blender.org/api/current/bpy.types.MaterialSlot.html#bpy.types.MaterialSlot.link