### PR TITLE
Update blender_manifest.toml to comply with Linux arch

### DIFF
--- a/import_3dm/blender_manifest.toml
+++ b/import_3dm/blender_manifest.toml
@@ -41,7 +41,7 @@ license = [
 # ]
 
 # Optional list of supported platforms. If omitted, the extension will be available in all operating systems.
-platforms = ["windows-x64", "macos-arm64", "linux-x86_64"]
+platforms = ["windows-x64", "macos-arm64", "linux-x64"]
 # Other supported platforms: "windows-arm64", "macos-x86_64"
 
 # Optional: bundle 3rd party Python modules.


### PR DESCRIPTION
See docs https://docs.blender.org/manual/en/latest/advanced/extensions/getting_started.html

Fix #138. https://docs.blender.org/manual/en/latest/advanced/extensions/getting_started.html shows that the correct value should be linux-x64