### PR TITLE
SubD changes

### DIFF
--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -176,6 +176,22 @@ class Import3dm(Operator, ImportHelper):
         default=True,
     ) # type: ignore
 
+    subD_level_viewport: IntProperty(
+        name="SubD Levels Viewport",
+        description="Number of subdivisions to perform in the 3D viewport.",
+        default=2,
+        min=0,
+        max=6,
+    ) # type: ignore
+
+    subD_level_render: IntProperty(
+        name="SubD Levels Render",
+        description="Number of subdivisions to perform when rendering.",
+        default=2,
+        min=0,
+        max=6,
+    ) # type: ignore
+
     def execute(self, context : bpy.types.Context):
         options : Dict[str, Any] = {
             "filepath":self.filepath,
@@ -197,6 +213,8 @@ class Import3dm(Operator, ImportHelper):
             "import_instances_grid_layout":self.import_instances_grid_layout,
             "import_instances_grid":self.import_instances_grid,
             "link_materials_to":self.link_materials_to,
+            "subD_level_viewport":self.subD_level_viewport,
+            "subD_level_render":self.subD_level_render
         }
         return read_3dm(context, options)
 
@@ -242,6 +260,11 @@ class Import3dm(Operator, ImportHelper):
         box.label(text="Materials")
         box.prop(self, "link_materials_to")
         box.prop(self, "update_materials")
+
+        box = layout.box()
+        box.label(text="SubD")
+        box.prop(self, "subD_level_viewport")
+        box.prop(self, "subD_level_render")
 
 # Only needed if you want to add into a dynamic menu
 def menu_func_import(self, _ : bpy.types.Context):

--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -192,6 +192,14 @@ class Import3dm(Operator, ImportHelper):
         max=6,
     ) # type: ignore
 
+    subD_boundary_smooth: EnumProperty(
+        items=(("ALL", "All", "Smooth boundaries, including corners"),
+               ("PRESERVE_CORNERS", "Keep Corners", "Smooth boundaries, but corners are kept sharp"),),
+        name="SubD Boundary Smooth",
+        description="Controls how open boundaries are smoothed",
+        default="ALL",
+    ) # type: ignore
+
     def execute(self, context : bpy.types.Context):
         options : Dict[str, Any] = {
             "filepath":self.filepath,
@@ -214,7 +222,8 @@ class Import3dm(Operator, ImportHelper):
             "import_instances_grid":self.import_instances_grid,
             "link_materials_to":self.link_materials_to,
             "subD_level_viewport":self.subD_level_viewport,
-            "subD_level_render":self.subD_level_render
+            "subD_level_render":self.subD_level_render,
+            "subD_boundary_smooth":self.subD_boundary_smooth,
         }
         return read_3dm(context, options)
 
@@ -265,6 +274,7 @@ class Import3dm(Operator, ImportHelper):
         box.label(text="SubD")
         box.prop(self, "subD_level_viewport")
         box.prop(self, "subD_level_render")
+        box.prop(self, "subD_boundary_smooth")
 
 # Only needed if you want to add into a dynamic menu
 def menu_func_import(self, _ : bpy.types.Context):

--- a/import_3dm/converters/__init__.py
+++ b/import_3dm/converters/__init__.py
@@ -132,10 +132,9 @@ def convert_object(
     # If subd, apply subdivision modifier
     if ob.Geometry.ObjectType == r3d.ObjectType.SubD:
         if blender_object.modifiers.find("SubD") == -1:
-            level = 3
             blender_object.modifiers.new(type="SUBSURF", name="SubD")
-            blender_object.modifiers["SubD"].levels = level
-            blender_object.modifiers["SubD"].render_levels = level
+            blender_object.modifiers["SubD"].levels = options.get("subD_level_viewport", 2)
+            blender_object.modifiers["SubD"].render_levels = options.get("subD_level_render", 2)
 
     # Import Rhino user strings
     for pair in ob.Attributes.GetUserStrings():

--- a/import_3dm/converters/__init__.py
+++ b/import_3dm/converters/__init__.py
@@ -135,6 +135,7 @@ def convert_object(
             blender_object.modifiers.new(type="SUBSURF", name="SubD")
             blender_object.modifiers["SubD"].levels = options.get("subD_level_viewport", 2)
             blender_object.modifiers["SubD"].render_levels = options.get("subD_level_render", 2)
+            blender_object.modifiers["SubD"].boundary_smooth = options.get("subD_boundary_smooth", "ALL")
 
     # Import Rhino user strings
     for pair in ob.Attributes.GetUserStrings():

--- a/import_3dm/converters/render_mesh.py
+++ b/import_3dm/converters/render_mesh.py
@@ -46,7 +46,6 @@ def import_render_mesh(context, ob, name, scale, options):
     elif og.ObjectType == r3d.ObjectType.SubD:
         msh = [r3d.Mesh.CreateFromSubDControlNet(og, False)]
         msh_tex = [r3d.Mesh.CreateFromSubDControlNet(og, True)]
-        # needs_welding = True
     elif og.ObjectType == r3d.ObjectType.Brep:
         msh = [og.Faces[f].GetMesh(r3d.MeshType.Any) for f in range(len(og.Faces)) if type(og.Faces[f])!=list]
     fidx = 0


### PR DESCRIPTION
# Various changes for SubDs

* adds import options for SubD levels and "boundary smooth"
* updates importer to read texture coordinates of SubDs as UV coordinates

## detailed explanation
Adds options to set viewport and render subD levels as well as boundary smoothing.

The changes for UVs on SubDs will only read the texture coordinates from the SubD itself. This does not support UVs created with the Unwarp command in Rhino for SubDs as those are stored on a separate mapping mesh with a different topology.
