### PR TITLE
Option to import layers as empties

### DIFF
--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -76,6 +76,12 @@ class Import3dm(Operator, ImportHelper):
         default=True,
     ) # type: ignore
 
+    import_layers_as_empties: BoolProperty(
+        name="Layers as Empties",
+        description="Import iayers as empties instead of groups.",
+        default=True,
+    ) # type: ignore
+
     import_annotations: BoolProperty(
         name="Annotations",
         description="Import annotations.",
@@ -191,6 +197,7 @@ class Import3dm(Operator, ImportHelper):
             "update_materials":self.update_materials,
             "import_hidden_objects":self.import_hidden_objects,
             "import_hidden_layers":self.import_hidden_layers,
+            "import_layers_as_empties": self.import_layers_as_empties,
             "import_groups":self.import_groups,
             "import_nested_groups":self.import_nested_groups,
             "import_instances":self.import_instances,
@@ -218,6 +225,11 @@ class Import3dm(Operator, ImportHelper):
         box.label(text="Visibility")
         box.prop(self, "import_hidden_objects")
         box.prop(self, "import_hidden_layers")
+
+        box = layout.box()
+        box.label(text="Layers")
+        row = box.row()
+        row.prop(self, "import_layers_as_empties")
 
         box = layout.box()
         box.label(text="Views")

--- a/import_3dm/converters/__init__.py
+++ b/import_3dm/converters/__init__.py
@@ -151,8 +151,18 @@ def convert_object(
     #instance definition objects are linked within their definition collections
     if not ob.Attributes.IsInstanceDefinitionObject:
         try:
-            layer.objects.link(blender_object)
-            if text_object:
-                layer.objects.link(text_object)
+            if options.get("import_layers_as_empties", False):
+                blender_object.parent = layer
+                if text_object is not None:
+                    text_object.parent = layer
+                # also link object to same collections as parent
+                for col in layer.users_collection:
+                    col.objects.link(blender_object)
+                    if text_object is not None:
+                        col.objects.link(text_object)
+            else:
+                layer.objects.link(blender_object)
+                if text_object is not None:
+                    layer.objects.link(text_object)
         except Exception:
             pass

--- a/import_3dm/converters/render_mesh.py
+++ b/import_3dm/converters/render_mesh.py
@@ -24,6 +24,7 @@ import rhino3dm as r3d
 from . import utils
 import bpy
 import bmesh
+import bpy.app
 
 def import_render_mesh(context, ob, name, scale, options):
     # concatenate all meshes from all (brep) faces,

--- a/import_3dm/converters/utils.py
+++ b/import_3dm/converters/utils.py
@@ -113,7 +113,8 @@ def get_dict_for_base(base : bpy.types.bpy_prop_collection) -> Dict[str, bpy.typ
 def get_or_create_iddata(
         base    : bpy.types.bpy_prop_collection,
         tag_dict: Dict[str, Any],
-        obdata : bpy.types.ID
+        obdata : bpy.types.ID,
+        use_none : bool = False
     )   -> bpy.types.ID:
     """
     Get an iddata.
@@ -142,7 +143,7 @@ def get_or_create_iddata(
         if obdata and type(theitem) != type(obdata):
             theitem.data = obdata
     else:
-        if obdata:
+        if obdata or use_none:
             theitem = base.new(name=name, object_data=obdata)
         else:
             theitem = base.new(name=name)

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -83,6 +83,7 @@ def read_3dm(
     import_named_views = options.get("import_named_views", False)
     import_hidden_objects = options.get("import_hidden_objects", False)
     import_hidden_layers = options.get("import_hidden_layers", False)
+    import_layers_as_empties = options.get("import_layers_as_empties", False)
     import_groups = options.get("import_groups", False)
     import_nested_groups = options.get("import_nested_groups", False)
     import_instances = options.get("import_instances",False)
@@ -121,7 +122,8 @@ def read_3dm(
     converters.handle_materials(context, model, materials, update_materials)
 
     # Handle layers
-    converters.handle_layers(context, model, toplayer, layerids, materials, update_materials, import_hidden_layers)
+    converters.handle_layers(context, model, toplayer, layerids, materials, update_materials, import_hidden_layers, import_layers_as_empties)
+    materials[converters.DEFAULT_RHINO_MATERIAL] = None
 
     #build skeletal hierarchy of instance definitions as collections (will be populated by object importer)
     if import_instances:


### PR DESCRIPTION
# Adds an option to import layers as empties

Using empties instead of collections allows for a different way to manage and work with these in blender.
This way objects may only be "assigned to on layer" whereas collections allow to add an object to multiple collections.
