### PR TITLE
Fixes issue with failed import due to error thrown

### DIFF
--- a/import_3dm/__init__.py
+++ b/import_3dm/__init__.py
@@ -206,6 +206,10 @@ class Import3dm(Operator, ImportHelper):
         default="ALL",
     ) # type: ignore
 
+    @classmethod
+    def poll(cls, context: bpy.types.Context):
+        return context.mode == "OBJECT"
+
     def execute(self, context : bpy.types.Context):
         options : Dict[str, Any] = {
             "filepath":self.filepath,

--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -223,8 +223,12 @@ def read_3dm(
     if bpy.app.version[0] < 4:
         bpy.ops.object.shade_smooth({'selected_editable_objects': toplayer.all_objects})
     else:
+        # set the active object on the viewlayer to none as that is checked by shade smooth
+        active_object = bpy.context.view_layer.objects.active
+        bpy.context.view_layer.objects.active = None
         with context.temp_override(selected_editable_objects=toplayer.all_objects):
             bpy.ops.object.shade_smooth()
+        bpy.context.view_layer.objects.active = active_object
 
     converters.cleanup()
 


### PR DESCRIPTION
# Fixes issue with failed import due to error thrown

With an object selected that is not a mesh, import would fail due to shade smooth throwing and error. Trying to import while in edit mode would also fail.