### PR TITLE
Fixes error with removal of temporary files

### DIFF
--- a/import_3dm/converters/material.py
+++ b/import_3dm/converters/material.py
@@ -32,6 +32,7 @@ from pathlib import Path, PureWindowsPath, PurePosixPath
 import base64
 import tempfile
 import uuid
+import os
 
 from typing import Any, Tuple
 
@@ -492,8 +493,9 @@ def handle_embedded_files(model : r3d.File3dm):
 
         tmpfpath = tmpf.name
         try:
-            tmpfpath.unlink()
-        except:
+            tmpf.close()
+            os.unlink(tmpfpath)
+        except RuntimeError:
             pass
 
 


### PR DESCRIPTION
# Fixes error with removal of temporary files

Trying to import a Rhino file with packet texture would sometimes throw an error due to temporary files not being removed properly.