### PR TITLE
Drag and drop support

### DIFF
--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -66,6 +66,7 @@ def create_or_get_top_layer(context, filepath):
 
 def read_3dm(
         context : bpy.types.Context,
+        filepath : str,
         options : Dict[str, Any]
     )   -> Set[str]:
 
@@ -89,7 +90,6 @@ def read_3dm(
     import_instances = options.get("import_instances",False)
     update_materials = options.get("update_materials", False)
 
-    filepath : str = options.get("filepath", "")
     model = None
 
     try:


### PR DESCRIPTION
# Adds filehander for drag and drop of 3dm file onto blender

This PR adds support to drag and drop 3dm files onto blender. It also adds bl_options, preventing blender from crashing on consecutive imports.
Refactors passing on operator options and filepath to internal functions, inspired by official GLTF importer.