### PR TITLE
Feature: Auto install `rhino3dm`

### DIFF
--- a/import_3dm/read3dm.py
+++ b/import_3dm/read3dm.py
@@ -35,7 +35,6 @@ def modules_path():
     modulespath = os.path.normpath(
         os.path.join(
             bpy.utils.script_path_user(),
-            "addons",
             "modules"
         )
     )
@@ -48,12 +47,18 @@ def modules_path():
 
     return modulespath
 
-modules_path()
+target_path = modules_path()
 
-
-import rhino3dm as r3d
+try:
+    import rhino3dm as r3d
+except ImportError:
+    import subprocess
+    print('Attempting to install dependencies to {}'.format(target_path))
+    env = os.environ.copy()
+    for dep_name in ("rhino3dm",):
+        res = subprocess.run( [sys.executable, "-m", "pip", "install", "--target", target_path, dep_name], env=env)
+    import rhino3dm as r3d
 from . import converters
-
 
 def create_or_get_top_layer(context, filepath):
     top_collection_name = Path(filepath).stem


### PR DESCRIPTION
Adds automatic installation of the rhino3dm dependency when it's not found, improving the user experience by eliminating manual dependency installation steps.

### Changes
- Wrapped the rhino3dm import in a try/except block to catch ImportError
- On import failure, automatically installs `rhino3dm` using `pip` to the Blender modules directory
- Fixed the modules path by removing the redundant "addons" subdirectory

It uses `subprocess.run()` to execute `pip install --target` with the appropriate modules path, then re-imports rhino3dm after successful installation.