### PR TITLE
Remove deprecated us of use_nodes from material.py

### DIFF
--- a/import_3dm/converters/material.py
+++ b/import_3dm/converters/material.py
@@ -199,7 +199,7 @@ class PlasterWrapper(ShaderWrapper):
     NODES_LIST = ShaderWrapper.NODES_LIST + NODES_LIST
 
     def __init__(self, material):
-        super(PlasterWrapper, self).__init__(material, is_readonly=False, use_nodes=True)
+        super(PlasterWrapper, self).__init__(material, is_readonly=False)
 
     def update(self):
         super(PlasterWrapper, self).update()
@@ -451,7 +451,6 @@ material_handlers = {
 }
 
 def harvest_from_rendercontent(model : r3d.File3dm, mat : r3d.RenderMaterial, blender_material : bpy.types.Material):
-    blender_material.use_nodes = True
     typeName = mat.TypeName
 
     material_handler = material_handlers.get(typeName, not_yet_implemented)


### PR DESCRIPTION
# Remove use of `material.use_nodes` deprecated in Blender 5.0

`material.use_nodes` has been [deprecated in Blender 5.0](https://developer.blender.org/docs/release_notes/5.0/python_api/#shading).

## detailed explanation
* Removed use of `use_nodes` in the `PlasterWrapper` constructor and `harvest_from_rendercontent`.

## fixes / resolves
Importing a .3dm file in Blender 5.0 currently fails with the error:
```
Python: Traceback (most recent call last):
  File "/Users/<USER>/Library/Application Support/Blender/5.0/extensions/user_default/import_3dm/__init__.py", line 201, in execute
    return read_3dm(context, options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/<USER>/Library/Application Support/Blender/5.0/extensions/user_default/import_3dm/read3dm.py", line 121, in read_3dm
    converters.handle_materials(context, model, materials, update_materials)
  File "/Users/<USER>/Library/Application Support/Blender/5.0/extensions/user_default/import_3dm/converters/material.py", line 509, in handle_materials
    default_material(blmat)
  File "/Users/<USER>/Library/Application Support/Blender/5.0/extensions/user_default/import_3dm/converters/material.py", line 277, in default_material
    plaster = PlasterWrapper(blender_material)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/<USER>/Library/Application Support/Blender/5.0/extensions/user_default/import_3dm/converters/material.py", line 202, in __init__
    super(PlasterWrapper, self).__init__(material, is_readonly=False, use_nodes=True)
TypeError: ShaderWrapper.__init__() got an unexpected keyword argument 'use_nodes'
```

Removing the use of `use_nodes` resolves this and import apears to work in line with Blender 4.

This should fix #153, fix #155 and fix #157.
